### PR TITLE
Improve data robustness

### DIFF
--- a/polsalt/specpolwavmap.py
+++ b/polsalt/specpolwavmap.py
@@ -43,6 +43,9 @@ def specpolwavmap(infilelist, linelistlib="", automethod='Matchlines',
         config_dict = list_configurations(infilelist, log)
 
         for config in config_dict:
+            if len(config_dict[config]['arc']) == 0:
+                log.message('No Arc for this configuration:', with_header=False)
+                continue
         #set up some information needed later
             iarc = config_dict[config]['arc'][0]
             hduarc = pyfits.open(iarc)

--- a/scripts/correct_files.py
+++ b/scripts/correct_files.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import copy
+import numpy as np
 from astropy.io import fits
 
 import polsalt
@@ -9,7 +10,7 @@ from polsalt.specpolwollaston import correct_wollaston, read_wollaston
 datadir = os.path.dirname(polsalt.__file__) + '/data/'
 
 
-def correct_files(hdu):
+def correct_files(hdu,tilt=0):
     """For a given input file, apply corrections for wavelength, 
        distortion, and bad pixels
 
@@ -27,6 +28,7 @@ def correct_files(hdu):
     thdu[1].name = 'SCI'
     rpix_oc = read_wollaston(thdu, wollaston_file=datadir+"wollaston.txt")
     drow_oc = (rpix_oc-rpix_oc[:,cols/2][:,None])/rbin
+    drow_oc += -(tilt/cbin)*(np.arange(cols) - cols/2)/cols
  
     for i in range(1, len(hdu)):
        for o in range(beams):


### PR DESCRIPTION
specpolwavmap.py        46-48: graceful exit if no arc
specpolutils.py         116-124: allow use of arc from different blockid if necessary
scripts/specpolextract_sc.py:   23-43: correct for image tilt
scripts/correct_files.py:       13,31: correct for image tilt
