### PR TITLE
HWCal file, Misc fixes

### DIFF
--- a/polsalt/specpolrawstokes.py
+++ b/polsalt/specpolrawstokes.py
@@ -240,7 +240,7 @@ def create_raw_stokes_file(first_pair_file, second_pair_file, output_file, wppat
     # difference: defined as 0.5 * ( (o1 - o2)/(o1+o2) - (e1-e2)/(e1+e2))
     stokes_sw[1, wok] = 0.5 * ((sci_fow[0, 1, wok] - sci_fow[1, 1, wok]) / (sci_fow[0, 1, wok] + sci_fow[1, 1, wok])
                                - (sci_fow[0, 0, wok] - sci_fow[1, 0, wok]) / (sci_fow[0, 0, wok] + sci_fow[1, 0, wok]))
-    var_sw[1, wok] = 0.5 * ((var_fow[0, 1, wok] + var_fow[1, 1, wok]) / (sci_fow[0, 1, wok] + sci_fow[1, 1, wok]) ** 2
+    var_sw[1, wok] = 0.25 * ((var_fow[0, 1, wok] + var_fow[1, 1, wok]) / (sci_fow[0, 1, wok] + sci_fow[1, 1, wok]) ** 2
                             + (var_fow[0, 0, wok] + var_fow[1, 0, wok]) / (sci_fow[0, 0, wok] + sci_fow[1, 0, wok]) ** 2)
 
     stokes_sw[1] *= stokes_sw[0]

--- a/polsalt/specpolwavmap.py
+++ b/polsalt/specpolwavmap.py
@@ -297,7 +297,7 @@ def wave_map(dbfilename, edgerow_d, rows, cols, ystart, order=3, log=None):
     if cofrows < 5:
     # assume this is short MOS slit: use ystart solution for all rows, undo the slit edge settings
         log.message('FEW DATABASE ROWS, ASSUME MOS, USE START' , with_header=False)                    
-        legcof_l = legcof_lY[:,legy_Y==ystart].ravel()
+        legcof_l = legcof_lY[:,legy_Y.astype(int)==ystart].ravel()
         wavmap_yc = np.tile(np.polynomial.legendre.legval(np.arange(-cols/2,cols/2),legcof_l)[:,None],rows/2).T
         edgerow_d = 0,rows/2
         cofrows = 1


### PR DESCRIPTION
specpolextract_sc.py    132-137: fix error in flux preservation
RSSPol_HW_Calibration.py            update grid, polaroid flip handling
RSSPol_HW_Calibration_20061031.txt  new calibration file
specpolwavmap.py        300: fix fallback of wavmap to ystart row
specpolrawstokes.py     243: fix overestimated raw stokes variance
specpolfinalstokes.py   208-219: allow fallbacks for incomplete Linear-Hi
                        114-119: allow for mismatch of extracted wavelength grids
            197,225: allow for missing pairs in multicycle run
specpolview.py          107-111: fix mean err div0
            204-210: fix binning crash
