### PR TITLE
0501/17->, knjun17_1

### DIFF
--- a/polsalt/scrunch1d.py
+++ b/polsalt/scrunch1d.py
@@ -2,7 +2,7 @@
 
 # Resample data into new bins, preserving flux
 # New version 150912, much faster
-# New version 160322, fixed case where output bin coverage is larger than input bin coverage
+# New version 170504, fixed case where output bin coverage is larger than input bin coverage
 
 import os, sys, time, glob, shutil
 import numpy as np
@@ -12,18 +12,20 @@ def scrunch1d(input,binedge):
     na = input.size
     nx = binedge.size - 1
     input_a = np.append(input,0)                         # deal with edge of array
-    okxbin = ((binedge>=0) & (binedge<=na))                      
+#    okxbin = ((binedge>=0) & (binedge<=na))                      
+    okxbin = ((binedge[1:]>0) & (binedge[:-1]<na))
+    okxedge = np.zeros(binedge.size,dtype=bool)
+    okxedge[:-1] |= okxbin
+    okxedge[1:] |= okxbin                      
     output_x = np.zeros(nx)
 
 # _s: subbins divided by both new and old bin edges
-    ixmin = np.where(okxbin)[0][0]
-    ixmax = np.where(okxbin)[0][-1]
+    ixmin,ixmax = np.where(okxedge)[0][[0,-1]]
     iamin = int(binedge[ixmin])
     iamax = int(binedge[ixmax])
-    x_s = np.append(binedge[okxbin],range(int(np.ceil(binedge[ixmin])),iamax+1))
+    x_s = np.append(binedge[okxedge],range(int(np.ceil(binedge[ixmin])),iamax+1))
     x_s,argsort_s = np.unique(x_s,return_index=True)
     ia_s = x_s.astype(int)
-
     ix_s = np.append(np.arange(ixmin,ixmax+1),-1*np.ones(iamax-iamin+1))[argsort_s].astype(int)
     while (ix_s==-1).sum():
         ix_s[ix_s==-1] = ix_s[np.where(ix_s==-1)[0] - 1]

--- a/polsalt/specpolrawstokes.py
+++ b/polsalt/specpolrawstokes.py
@@ -74,6 +74,7 @@ def specpolrawstokes(infilelist, logfile='salt.log'):
         configs = 0
         obss = 0
         for i in range(images):
+            hdul = pyfits.open(infilelist[i])
             if (wpstate_i[i] == 'unknown'):
                 log.message( 'Warning: Image %s WP-STATE UNKNOWN, assume it is 3 (HW)' % img_i[i], with_header=False)
                 wpstate_i[i] = 'hw'
@@ -87,7 +88,11 @@ def specpolrawstokes(infilelist, logfile='salt.log'):
             grating = obs_dict['GRATING'][i].strip()
             grang = float(obs_dict['GR-ANGLE'][i])
             artic = float(obs_dict['CAMANG'][i])
-            confdat_d = [rbin, cbin, grating, grang, artic, wppat_i[i]]
+            wav0 = hdul[0].header['CRVAL1']
+            dwav = hdul[0].header['CDELT1']
+            wavs = hdul['SCI'].data.shape[-1]
+
+            confdat_d = [rbin, cbin, grating, grang, artic, wav0, dwav, wavs, wppat_i[i]]
             obsdat_d = [ object_i[i], rbin, cbin, grating, grang, artic, wppat_i[i]]
             if configs == 0:
                 confdat_cd = [confdat_d]

--- a/polsalt/specpolutils.py
+++ b/polsalt/specpolutils.py
@@ -41,7 +41,7 @@ def datedline(filename,date):
     ----------
     filename: string
         skips lines without first field [yyyymmdd]_v[nn] datever label
-    date: yyyymmdd of observation
+    date: string or int yyyymmdd of observation
 
     Returns: string which is selected line from file (including datever label)
 
@@ -51,9 +51,9 @@ def datedline(filename,date):
 
     line = ""
     for (l,datever) in enumerate(datever_l):
-        if date < datever[:8]: continue
+        if (int(date) < int(datever[:8])): continue
         for (v,vdatever) in enumerate(datever_l[l:]):
-            if vdatever[:8] > datever[:8]: continue
+            if (int(vdatever[:8]) > int(datever[:8])): continue
             datever = datever_l[l+v]
             line = line_l[l+v]
  

--- a/polsalt/specpolview.py
+++ b/polsalt/specpolview.py
@@ -237,12 +237,22 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
             textfile.truncate(0)
         else: print >>textfile
 
-        print >>textfile, name+'   '+obsdate+'\n\n'+'Wavelen   '+(4*" ").join(stokeslist[1:stokess])+(2*" ")+   \
+        print >>textfile, name+'   '+obsdate
+        if bintype== 'unbin':                       # for unbinned data, print out intensity as first column
+            print >>textfile, '\nWavelen        '+(4*" ").join(stokeslist[:stokess])+(2*" ")+   \
                 " Err   ".join(stokeslist[1:stokess])+' Err '+'   Syserr'
-        print >>textfile, ((' wtdavg  '+fmt) % (tuple(wtavview_s0[1:,0])+tuple(wtaverr_s0[1:,0]))),
-        if hassyserr: print >>textfile,('%8.3f' % hdul[0].header['SYSERR']),
-        print >>textfile,'\n'
-        np.savetxt(textfile,np.vstack((wav_v,nstokes_sv[1:],nerr_sv[1:])).T, fmt=(fmt_s[0]+fmt))
+            print >>textfile, ((' wtdavg            '+fmt) % (tuple(wtavview_s0[1:,0])+tuple(wtaverr_s0[1:,0]))),
+            if hassyserr: print >>textfile,('%8.3f' % hdul[0].header['SYSERR']),
+            print >>textfile,'\n'
+            np.savetxt(textfile,np.vstack((wav_v,stokes_sw[0,ok_sw[0]],nstokes_sv[1:],nerr_sv[1:])).T,  \
+                 fmt=("%8.2f %10.2f"+fmt))
+        else:
+            print >>textfile, '\nWavelen   '+(4*" ").join(stokeslist[1:stokess])+(2*" ")+   \
+                " Err   ".join(stokeslist[1:stokess])+' Err '+'   Syserr'
+            print >>textfile, ((' wtdavg  '+fmt) % (tuple(wtavview_s0[1:,0])+tuple(wtaverr_s0[1:,0]))),
+            if hassyserr: print >>textfile,('%8.3f' % hdul[0].header['SYSERR']),
+            print >>textfile,'\n'
+            np.savetxt(textfile,np.vstack((wav_v,nstokes_sv[1:],nerr_sv[1:])).T, fmt=("%8.2f "+fmt))
 
     if saveplot:
         plot_s[0].set_ylim(bottom=0)                # intensity plot default baseline 0

--- a/polsalt/specpolwollaston.py
+++ b/polsalt/specpolwollaston.py
@@ -106,5 +106,5 @@ def correct_wollaston(data, drow_shift):
     rows,cols = data.shape
     sdata = np.zeros(data.shape, dtype='float32')
     for c in range(cols):
-        shift(data[:,c], drow_shift[c], sdata[:,c])
+        shift(data[:,c], drow_shift[c], sdata[:,c], order=1)
     return sdata

--- a/scripts/correct_files.py
+++ b/scripts/correct_files.py
@@ -32,7 +32,16 @@ def correct_files(hdu,tilt=0):
  
     for i in range(1, len(hdu)):
        for o in range(beams):
-          hdu[i].data[o] = correct_wollaston(hdu[i].data[o], -drow_oc[o])
+
+          if hdu[i].name == 'BPM' :
+                tdata = hdu[i].data[o].astype('float')                          
+          else:                     
+                tdata = hdu[i].data[o]
+          tdata = correct_wollaston(tdata, -drow_oc[o])
+          if hdu[i].name == 'BPM' : 
+                hdu[i].data[o] = (tdata > 0.1).astype('uint')
+          else:                     
+                hdu[i].data[o] = tdata 
         
     return hdu
 

--- a/scripts/reducepoldata_sc.py
+++ b/scripts/reducepoldata_sc.py
@@ -1,7 +1,7 @@
 import os, sys, glob
-reddir = '/d/carol/Synched/software/SALT/polsaltcopy/polsalt/'
-scrdir = '/d/carol/Synched/software/SALT/polsaltcopy/scripts/'
-poldir = '/d/carol/Synched/software/SALT/polsaltcopy/'
+reddir = '/d/freyr/Synched/software/SALT/polsaltcurrent/polsalt/'
+scrdir = '/d/freyr/Synched/software/SALT/polsaltcurrent/scripts/'
+poldir = '/d/freyr/Synched/software/SALT/polsaltcurrent/'
 sys.path.extend((reddir,scrdir,poldir))
 
 datadir = reddir+'data/'
@@ -24,10 +24,9 @@ if not os.path.isdir('sci'): os.mkdir('sci')
 os.chdir('sci')
 
 #basic image reductions
-infilelist = glob.glob('../raw/P*fits')
+infilelist = sorted(glob.glob('../raw/P*fits'))
 
-#imred(infilelist, './', datadir+'bpm_rss_11.fits', cleanup=False)
-imred(infilelist, './', datadir+'bpm_rss_11.fits', cleanup=True)
+imred(infilelist, './', datadir+'bpm_rss_11.fits', crthresh=False, cleanup=True)
 
 #basic polarimetric reductions
 # debug=True
@@ -37,7 +36,7 @@ logfile='specpol'+obsdate+'.log'
 #wavelength map
 infilelist = sorted(glob.glob('m*fits'))
 linelistlib=""
-specpolwavmap(infilelist, linelistlib=linelistlib, logfile=logfile)
+#specpolwavmap(infilelist, linelistlib=linelistlib, logfile=logfile)
 
 #background subtraction and extraction
 infilelist = sorted(glob.glob('wm*fits'))


### PR DESCRIPTION
scrunch1d.py            fix case where output bins extend farther than input
specpolwavmap.py        implement CR correction using quartile fencing on distribution
                        of values over polarimetric cycle
specpolwollaston.py     change shift: order=1 interpolation to avoid overshoot (esp. bpm)
specpolutils.py         update handling of dates
specpolrawstokes.py     count as different configuration if wav grid is different
specpolfinalstokes.py   flag off bins with larger chisq
specpolview.py          print out intensity for unbinned data
imred.py                puts new CRCLEAN keyword in header with threshhold
scripts/reducepoldata.py remove CR cleaning from imred step
scripts/specpolextract.py   allow it to work on a subset of files in sci
			    use bpm mask in extract
			    do not set bpm for wavelength unless >25% of spectrum is bad
			    always recompute c* files
scripts/correct_files.py    correct handling of BPM