### PR TITLE
knsep17_2

### DIFF
--- a/dirprep.py
+++ b/dirprep.py
@@ -1,0 +1,18 @@
+# dirprep puts the polsalt directory (where it resides) path text in the second line 
+#   of selected tools in the script directory so that they may be run standalone
+
+import os, sys, glob
+poldir= os.path.dirname(os.path.abspath( __file__ ))+'/'    
+
+scrdir=poldir+'scripts/'
+toollist = [scrdir+'reducepoldata_sc.py',scrdir+'script.py']
+
+for tool in toollist:
+    with open(tool,'r') as f:
+        get_all=f.readlines()
+    with open(tool,'w') as f:
+        for i,line in enumerate(get_all,1):             
+            if i == 2:                             
+                f.writelines("poldir = "+"'"+poldir+"'\n")
+            else:
+                f.writelines(line)

--- a/polsalt/data/spst_filenames.txt
+++ b/polsalt/data/spst_filenames.txt
@@ -1,0 +1,23 @@
+# CAL_SPST file names
+CD-32d9927	mcd32d9927.dat   Ham-T
+EG21	meg21_extr.dat Ham-T
+EG274	meg274.dat    Ham-T
+Feige110	mfeige110_hst.dat  HST
+G138-31	mg138_31.dat    Oke
+G24-9	mg24_9.dat    Oke
+G93-48	mg93_48.dat  HST
+GD108	mgd108.dat    HST
+GD50	mgd50.dat  HST
+HD49798	mhd49798.dat    HST
+HILT600	mhilt600_extr.dat   Ham-T
+HR5501	mhr5501.dat   Ham-S
+HR7596	mhr7596_extr.dat   Ham-S
+LTT1788	mltt1788.dat   ?
+LTT2415	mltt2415.dat   Ham-T
+LTT3218	mltt3218.dat   Ham-T
+LTT4364	mltt4364_extr.dat   Ham-T
+LTT4816	mltt4816.dat   Ham-T
+LTT6248	mltt6248_extr.dat   Ham-T
+LTT7379	mltt7379_extr.dat   Ham-T
+LTT7987	mltt7987_extr.dat   Ham-T
+LTT9239	mltt9239.dat   Ham-T

--- a/polsalt/scrunch1d.py
+++ b/polsalt/scrunch1d.py
@@ -3,6 +3,7 @@
 # Resample data into new bins, preserving flux
 # New version 150912, much faster
 # New version 170504, fixed case where output bin coverage is larger than input bin coverage
+# New version 170909, again fixed case where output bin coverage is larger than input bin coverage
 
 import os, sys, time, glob, shutil
 import numpy as np
@@ -25,6 +26,8 @@ def scrunch1d(input,binedge):
     iamax = int(binedge[ixmax])
     x_s = np.append(binedge[okxedge],range(int(np.ceil(binedge[ixmin])),iamax+1))
     x_s,argsort_s = np.unique(x_s,return_index=True)
+    x_s = np.maximum(x_s,0.)                            # 20170909: deal with edge of array
+    x_s = np.minimum(x_s,na)                            # 20170909: deal with edge of array
     ia_s = x_s.astype(int)
     ix_s = np.append(np.arange(ixmin,ixmax+1),-1*np.ones(iamax-iamin+1))[argsort_s].astype(int)
     while (ix_s==-1).sum():
@@ -35,6 +38,7 @@ def scrunch1d(input,binedge):
 # divide data into subbins, preserving flux
     ix_x = np.zeros(nx+1).astype(int)
     s_x = np.zeros(nx+1).astype(int)
+
     input_s = input_a[ia_s[:-1]]*(x_s[1:] - x_s[:-1])
     ix_x[ixmin:(ixmax+1)], s_x[ixmin:(ixmax+1)] = np.unique(ix_s,return_index=True)
     ns_x = s_x[1:] - s_x[:-1]

--- a/polsalt/specpolrawstokes.py
+++ b/polsalt/specpolrawstokes.py
@@ -26,8 +26,6 @@ import reddir
 # from . import reddir
 datadir = os.path.dirname(inspect.getfile(reddir)) + "/data/"
 np.set_printoptions(threshold=np.nan)
-debug = True
-
 
 def specpolrawstokes(infilelist, logfile='salt.log', debug=False):
     """Produces an unnormalized stokes measurement in intensity from
@@ -131,6 +129,10 @@ def specpolrawstokes(infilelist, logfile='salt.log', debug=False):
             idx_j = np.where(obs_i == obs)[0]
             i0 = idx_j[0]
             name_n = []
+            if wppat_i[i0].count('NONE'):
+                log.message((('\n     %s  WP Pattern: NONE. Calibration data, skipped') % infilelist[i0]),  \
+                    with_header=False)
+                continue
             if wppat_i[i0].count('UNKNOWN'):
                 if (hsta_i[idx_j] % 2).max() == 0:
                     wppat = "LINEAR"
@@ -196,7 +198,7 @@ def specpolrawstokes(infilelist, logfile='salt.log', debug=False):
     return
 
 
-def create_raw_stokes_file(first_pair_file, second_pair_file, wav0, wavs, output_file, wppat=None):
+def create_raw_stokes_file(first_pair_file, second_pair_file, wav0, wavs, output_file, wppat=None, debug=False):
     """Create the raw stokes file.
 
     Parameters

--- a/polsalt/specpolutils.py
+++ b/polsalt/specpolutils.py
@@ -202,6 +202,7 @@ def list_configurations(infilelist, log):
     
     """
     # set up the observing dictionary
+    arclamplist = ['Ar','CuAr','HgAr','Ne','NeAr','ThAr','Xe']
     obs_dict=obslog(infilelist)
 
     # hack to remove potentially bad data
@@ -248,8 +249,11 @@ def list_configurations(infilelist, log):
                      (obs_tab['BVISITID']==blockvisit)
                )
 
-        objtype = obs_tab['CCDTYPE']          # kn changed from OBJECT: CCDTYPE lists ARC consistently
-        image_dict['arc'] = infilelist[mask * (objtype == 'ARC')]
+        objtype = obs_tab['CCDTYPE']    # kn changed from OBJECT: CCDTYPE lists ARC more consistently
+        lamp = obs_tab['LAMPID']
+        isarc = ((objtype == 'ARC') | np.in1d(lamp,arclamplist))
+                                        # kn added check for arc lamp when CCDTYPE incorrect        
+        image_dict['arc'] = infilelist[mask * isarc]
 
         # if no arc for this config look for a similar one with different BVISITID
         if len(image_dict['arc']) == 0:
@@ -262,7 +266,7 @@ def list_configurations(infilelist, log):
                 log.message("Warning: using arc from different BLOCKID", with_header=False)                
             
         image_dict['flat'] = infilelist[mask * (objtype == 'FLAT')]
-        image_dict['object'] = infilelist[mask * (objtype != 'ARC') *  (objtype != 'FLAT')]
+        image_dict['object'] = infilelist[mask * ~isarc *  (objtype != 'FLAT')]
         if len(image_dict['object']) == 0: continue
         config_dict[(grating, grtilt, camang, blockvisit)] = image_dict
 


### PR DESCRIPTION
dirprep.py                      new github initialization script: embed polsalt dir in scripts
polsalt/specpolutils.py         mod list_configurations to identify as arc if lamp in arclamplist
polsalt/scrunch1d.py            fix (again) case where output bins extend farther than input
polsalt/specpolrawstokes        properly ignores WPPATERN=NONE calibration data
data/spst_filenames.txt         new file for fluxcaling
scripts/specpolflux.py          new module to compute and apply flux calibration data
scripts/specpolfinalstokes.py   moved from polsalt, put specpolflux at the end
scripts/specpolview.py          moved from polsalt, updated to handle fluxed data
scripts/reducepoldata_sc.py     now initable by dirprep
scripts/script.py               new script runs scripts tools as standalone; initable by dirprep