### PR TITLE
knsep17_5

### DIFF
--- a/scripts/specpolfinalstokes.py
+++ b/scripts/specpolfinalstokes.py
@@ -18,12 +18,13 @@ from iraf import pysalt
 from saltobslog import obslog
 from saltsafelog import logging
 
+polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
+datadir = polsaltdir+'/polsalt/data/'
+sys.path.extend((polsaltdir+'/polsalt/',))
+
 from specpolutils import datedfile, datedline
 from specpolview import wtavstokes, printstokes
 from specpolflux import specpolflux
-
-import reddir
-datadir = os.path.dirname(inspect.getfile(reddir))+"/data/"
 
 np.set_printoptions(threshold=np.nan)
 
@@ -508,12 +509,12 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     log.message(open('tmp.log').read(), with_header=False)
                     os.remove('tmp.log')
 
-                # save final stokes fits file for this observation
+                # save final stokes fits file for this observation.  Strain out nans.
                     infile = infilelist[rawlist[comblist[k][0]][0]]
                     hduout = pyfits.open(infile)
-                    hduout['SCI'].data = stokes_Fw.astype('float32').reshape((3,1,-1))
+                    hduout['SCI'].data = np.nan_to_num(stokes_Fw.astype('float32').reshape((3,1,-1)))
                     hduout['SCI'].header['CTYPE3'] = 'I,Q,U'
-                    hduout['VAR'].data = var_Fw.astype('float32').reshape((4,1,-1))
+                    hduout['VAR'].data = np.nan_to_num(var_Fw.astype('float32').reshape((4,1,-1)))
                     hduout['VAR'].header['CTYPE3'] = 'I,Q,U,QU'
 
                     hduout['BPM'].data = bpm_Fw.astype('uint8').reshape((3,1,-1))

--- a/scripts/specpolflux.py
+++ b/scripts/specpolflux.py
@@ -18,15 +18,16 @@ from astropy.io import fits as pyfits
 from astropy.table import Table,unique
 from scipy.interpolate import interp1d
 
+polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
+datadir = polsaltdir+'/polsalt/data/'
+sys.path.extend((polsaltdir+'/polsalt/',))
+
 from pyraf import iraf
 from iraf import pysalt
 from saltobslog import obslog
 from saltsafelog import logging
 from scrunch1d import scrunch1d
 
-import reddir
-# from . import reddir
-DATADIR = os.path.dirname(inspect.getfile(reddir)) + "/data/"
 np.set_printoptions(threshold=np.nan)
 debug = True
 
@@ -43,7 +44,7 @@ def specpolflux(infilelist, logfile='salt.log', debug=False):
 
     """
   # Info on CAL_SPST files:
-    calspstname_s,calspstfile_s=np.loadtxt(DATADIR+"spst_filenames.txt",    \
+    calspstname_s,calspstfile_s=np.loadtxt(datadir+"spst_filenames.txt",    \
         dtype=str,usecols=(0,1),unpack=True)
     namelen = max(map(len,calspstname_s))
 
@@ -171,6 +172,7 @@ def specpolflux(infilelist, logfile='salt.log', debug=False):
             fluxcalhistory += " "+fluxdblist[e]
             fluxcallog += "  "+str(e+1)+" "+fluxdblist[e]
         fluxcal_w /= fluxdbentry_e.shape[0]
+        fluxcal_w = (np.nan_to_num(fluxcal_w))
         hdul['SCI'].data *= fluxcal_w
         hdul['SCI'].header['CUNIT3'] = cunitfluxed
         hdul['VAR'].data *= fluxcal_w**2

--- a/scripts/specpolview.py
+++ b/scripts/specpolview.py
@@ -19,7 +19,7 @@ plt.ioff()
 np.set_printoptions(threshold=np.nan)
 
 #---------------------------------------------------------------------------------------------
-def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
+def specpolview(infile_list, bin='unbin', save = '', debug=False):
     """View output results
 
     Parameters
@@ -27,33 +27,31 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
     infile_list: list
        one or more _stokes.fits files
 
-    bincode  
+    bin  
        unbin, nnA (nn Angstroms), nn% (binned to %)
 
-   saveoption  
+   save  
        '' (text to terminal), text (text to file), plot (terminal plot and pdf file), textplot (both)
 
     """
-
     obss = len(infile_list)
     bintype = 'unbin'
     errbars = False
-    if len(bincode):
-        if bincode.count('%'): 
+    if len(bin):
+        if bin.count('%'): 
             bintype = 'percent'
-            errbin = float(bincode[ :bincode.index('%')])
-        elif bincode.count('A'): 
+            errbin = float(bin[ :bin.index('%')])
+        elif bin.count('A'): 
             bintype = 'wavl'
-            blk = int(bincode[ :bincode.index('A')])
-        elif bincode != 'unbin': 
+            blk = int(bin[ :bin.index('A')])
+        elif bin != 'unbin': 
             print "unrecognized binning option, set to unbinned"
             bintype = 'unbin'
-    if len(bincode)>6:
-        errbars = (bincode[-6:]=="errors")
+    if len(bin)>6:
+        errbars = (bin[-6:]=="errors")
 
-    debug = saveoption.count('debug')>0
-    savetext = (saveoption.count('text')>0) | debug
-    saveplot = (saveoption.count('plot')>0) | debug
+    savetext = (save.count('text')>0)
+    saveplot = (save.count('plot')>0)
     plotcolor_o = ['b','g','r','c','m','y','k']
     askpltlim = True
     tcenter = 0.
@@ -175,7 +173,7 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
                 wgap0_g = wgap0_g[0:wgap1_g.shape[0]]
                 isbad_g = ((wgap1_g - wgap0_g) > allowedgap)
                 stokes_sw, err_sw = viewstokes(stokes_Sw,var_Sw,ok_w,tcenter)
-                binvar_w = nerr_sw[1]**2
+                binvar_w = err_sw[1]**2
                 ww = -1; b = 0;  bin_w = -1*np.ones((wavs))
                 while (bpm_Sw[0,ww+1:]==0).sum() > 0:
                     w = ww+1+np.where(bpm_Sw[0,ww+1:]==0)[0][0]
@@ -192,11 +190,11 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
                     b += 1
                 bin_w[bpm_Sw[0]>0] = -1
                 Bins  = b
-                if debug_out: 
-                    np.savetxt(name+'_'+bincode+'_binid.txt',np.vstack((wav_w,bin_w)).T,fmt="%8.2f %5i")
+                if debug: 
+                    np.savetxt(name+'_'+bin+'_binid.txt',np.vstack((wav_w,bin_w)).T,fmt="%8.2f %5i")
 
         # calculate binned data. _V = possible Bins, _v = good bins
-            bin_V = np.arange(Bins)                   
+            bin_V = np.arange(Bins)
             bin_Vw = (bin_V[:,None] == bin_w[None,:])
             stokes_SV = (stokes_Sw[:,None,:]*bin_Vw).sum(axis=2)
             var_SV = (var_Sw[:,None,:]*bin_Vw).sum(axis=2) 
@@ -210,8 +208,9 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
             stokes_sV, err_sV = viewstokes(stokes_SV,var_SV,ok_V,tcenter)          
             stokes_sv, err_sv = stokes_sV[:,ok_V], err_sV[:,ok_V]
             for S in range(1,stokess):
-                if debug_out: np.savetxt('errbar_'+str(S)+'.txt', \
-                    np.vstack((wav_v,stokes_sv[S-1],err_sv[S-1],dwavleft_v,dwavright_v)).T,fmt = "%10.4f")
+                if debug: np.savetxt('errbar_'+str(S)+'.txt', \
+                    np.vstack((wav_v,stokes_SV[S-1],var_SV[S-1],stokes_sv[S-1],err_sv[S-1],dwavleft_v,dwavright_v)).T,  \
+                    fmt = "%10.4f")
                 if errbars:
                     plot_S[S].errorbar(wav_v,stokes_sv[S-1],color=plotcolor,fmt='.',    \
                         yerr=err_sv[S-1],xerr=(dwavleft_v,dwavright_v),capsize=0)
@@ -221,7 +220,7 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
       # Printing for observation
         textfile = sys.stdout
         if savetext: 
-            textfile = open(name+'_'+bincode+'.txt','ab')
+            textfile = open(name+'_'+bin+'.txt','ab')
             textfile.truncate(0)
         else: print >>textfile
 
@@ -264,7 +263,7 @@ def specpolview(infile_list, bincode='unbin', saveoption = '', debug_out=False):
         if tags:                 # raw and final stokes files
             objlist = sorted(list(set(namelist[b].split("_")[0] for b in range(obss))))
             confcyclelist = sorted(list(set(namelist[b].replace("_stokes","").split("_",1)[-1] for b in range(obss))))
-            plotfile = '_'.join(objlist+confcyclelist+list([plotname,bincode]))+'.pdf'
+            plotfile = '_'.join(objlist+confcyclelist+list([plotname,bin]))+'.pdf'
         else:                               # diffsum files from diffsum
             plotfile = namelist[0]+'-'+namelist[-1][-4:]+'.pdf'
         plt.savefig(plotfile,orientation='portrait')
@@ -415,14 +414,9 @@ def printstokes(stokes_Sw,var_Sw,wav_w,textfile=sys.stdout,tcenter=0,isfluxed=Fa
 #---------------------------------------------------------------------------------------------
  
 if __name__=='__main__':
-    infile_list=sys.argv[1:]
-    saveoption = ''
-    bincode = 'unbin'
-    if infile_list[-1].count('text') | infile_list[-1].count('plot') | infile_list[-1].count('debug'):
-        saveoption = infile_list.pop()
-    if infile_list[-1][-5:] != '.fits':
-        bincode = infile_list.pop()
-    specpolview(infile_list, bincode, saveoption)
+    infilelist=[x for x in sys.argv[1:] if x.count('.fits')]
+    kwargs = dict(x.split('=', 1) for x in sys.argv[1:] if x.count('.fits')==0)  
+    specpolview(infilelist, **kwargs)
 
     
 


### PR DESCRIPTION
scripts/specpolflux.py      Allow imports to work on standalone execution
                            Get rid of Nan's
scripts/specpolfinalstokes  Allow imports to work on standalone execution
scripts/specpolview.py      Update name and use of kwargs