### PR TITLE
1226, kndec17_1

### DIFF
--- a/scripts/correct_files.py
+++ b/scripts/correct_files.py
@@ -4,11 +4,11 @@ import copy
 import numpy as np
 from astropy.io import fits
 
-import polsalt
-from polsalt.specpolwollaston import correct_wollaston, read_wollaston
+polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
+datadir = polsaltdir+'/polsalt/data/'
+sys.path.extend((polsaltdir+'/polsalt/',))
 
-datadir = os.path.dirname(polsalt.__file__) + '/data/'
-
+from specpolwollaston import correct_wollaston, read_wollaston
 
 def correct_files(hdu,tilt=0):
     """For a given input file, apply corrections for wavelength, 
@@ -17,6 +17,9 @@ def correct_files(hdu,tilt=0):
     Parameters
     ----------
     input_file: astropy.io.fits.HDUList
+
+    tilt: (float)
+        change in row from col = 0 to cols
     """
     
     cbin, rbin = [int(x) for x in hdu[0].header['CCDSUM'].split(" ")]
@@ -28,7 +31,7 @@ def correct_files(hdu,tilt=0):
     thdu[1].name = 'SCI'
     rpix_oc = read_wollaston(thdu, wollaston_file=datadir+"wollaston.txt")
     drow_oc = (rpix_oc-rpix_oc[:,cols/2][:,None])/rbin
-    drow_oc += -(tilt/cbin)*(np.arange(cols) - cols/2)/cols
+    drow_oc += -tilt*(np.arange(cols) - cols/2)/cols
  
     for i in range(1, len(hdu)):
        for o in range(beams):

--- a/scripts/reducepoldata_sc.py
+++ b/scripts/reducepoldata_sc.py
@@ -1,5 +1,5 @@
 import os, sys, glob, shutil
-print "Run toolprep first";exit()   # replaced with poldir text by toolprep.py
+poldir = '/d/freyr/Dropbox/software/SALT/polsaltcurrent/'
 
 reddir=poldir+'polsalt/'
 scrdir=poldir+'scripts/'
@@ -15,8 +15,9 @@ from specpolextract_sc import specpolextract_sc
 from specpolrawstokes import specpolrawstokes
 from specpolfinalstokes import specpolfinalstokes
 
+print sys.argv
 obsdate = sys.argv[1]
-
+print obsdate
 os.chdir(obsdate)
 if not os.path.isdir('sci'): os.mkdir('sci')
 shutil.copy(scrdir+'script.py','sci')
@@ -36,9 +37,12 @@ specpolwavmap(infilelist, linelistlib=linelistlib, logfile=logfile)
 
 #background subtraction and extraction
 infilelist = sorted(glob.glob('wm*fits'))
-dyasec = 5.     # star +/-5, bkg= +/-(25-35)arcsec:  2nd order is 9-20 arcsec away
-yoffo = 0.      # optional offset of target (bins) from brightest in O (bottom) image
-specpolextract_sc(infilelist,yoffo,dyasec, logfile=logfile)
+extract = 10.   # star +/-5, bkg= +/-(25-35)arcsec:  2nd order is 9-20 arcsec away
+locate = (-120.,120.)    # science target is brightest target in whole slit
+#locate = (-20.,20.)
+
+specpolextract_sc(infilelist,logfile=logfile,locate=locate,extract=extract)
+#specpolextract_sc(infilelist,logfile=logfile,locate=locate,extract=extract,docomp=True,useoldc=True)
 
 #raw stokes
 infilelist = sorted(glob.glob('e*fits'))

--- a/scripts/specpolextract_sc.py
+++ b/scripts/specpolextract_sc.py
@@ -10,173 +10,262 @@ import os, sys, glob, shutil
 import numpy as np
 from astropy.io import fits as pyfits
 from scipy.ndimage.filters import median_filter
+from scipy.interpolate import interp1d
 from correct_files import correct_files
 
 from PySpectrograph.Spectra import findobj, Spectrum
 
 import pylab as pl
 
-def specpolextract_sc(infilelist,yoffo,dyasec,logfile):
+polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
+datadir = polsaltdir+'/polsalt/data/'
+sys.path.extend((polsaltdir+'/polsalt/',))
+
+def specpolextract_sc(infilelist,*posargs,**kwargs):  
+    print '\nspecpolextract_sc version: 20171226'
+    if len(posargs):
+        print "Incorrect call of specpolextract_sc.  Likely need to update reducepoldata_sc.py from:"
+        print polsaltdir+'/scripts/reducepoldata_sc.py'
+        exit()
+    logfile = kwargs.pop('logfile','salt.log')
+    locatewindow = kwargs.pop('locate',(-120.,120.))
+    xtrwindow = kwargs.pop('extract',10.)
+    docomp = kwargs.pop('docomp',False)
+    useoldc = kwargs.pop('useoldc',False)
 
     log = open(logfile,'a')
+    print >> log, '\nspecpolextract_sc version: 20171226'  
 
-    # first estimate image tilt
+  # first estimate image tilt on brightest spectrum
     tilt_i = np.full(len(infilelist),np.nan)
     filestocorrect = 0
+    wollaston_file=datadir+"wollaston.txt"
+    lam_m = np.loadtxt(wollaston_file,dtype=float,usecols=(0,))
+    rpix_om = np.loadtxt(wollaston_file,dtype=float,unpack=True,usecols=(1,2))
 
     infilelist = sorted(infilelist)
     for i,img in enumerate(infilelist):
-#        if (os.path.exists('c' + img)): continue
-        hdu = pyfits.open(img)
-        if hdu[0].header['CCDTYPE'] == 'ARC': continue
-        filestocorrect += 1 
-        rows, cols = hdu['SCI'].data[0].shape
-        cbin, rbin = [int(x) for x in hdu[0].header['CCDSUM'].split(" ")]
-        if hdu[0].header['GRATING'].strip() == 'PG0300': 
-            y1,y2 = .25*cols,.5*cols                            # avoid 2nd order
-        else: y1,y2 = .25*cols,.75*cols 
-        col_c = (np.arange(y1-.05*cols,y1+.05*cols) + (y2-y1)*np.arange(2)[:,None]).astype(int)
-        y_oc = np.zeros((2,2))
-        for o,c in np.ndindex(2,2):  
-            y_oc[o,c] = np.median(hdu['SCI'].data[o,:,col_c[c]].sum(axis=0).argsort()[-17:])
-        tilt_i[i] = int((cols/(y2-y1))*cbin*(y_oc.mean(axis=0)[0]-y_oc.mean(axis=0)[1]))
-        print img,": image tilt: ",int(tilt_i[i])
-        print >>log,img,": image tilt: ",int(tilt_i[i])
+        if (useoldc & os.path.exists('c' + img)): continue
+        hdul = pyfits.open(img)
+        if hdul[0].header['CCDTYPE'] == 'ARC': continue
+        filestocorrect += 1
+        sci_orc = hdul['SCI'].data
+        rows, cols = sci_orc[0].shape
+        cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
+
+      # col_dC = columns C in each sample d=(0,1) centered at c_d (0,1)
+        if hdul[0].header['GRATING'].strip() == 'PG0300': 
+            c_d = (cols*np.array([.25,.5])).astype(int)                        # avoid 2nd order
+        else: c_d = (cols*np.array([.25,.75])).astype(int)
+        dc = c_d[1]-c_d[0]
+        col_dC = (np.arange(c_d[0]-.05*cols,c_d[0]+.05*cols) + dc*np.arange(2)[:,None]).astype(int)
+
+      # row_odR = rows R to sample centered on untilted polarimetric spectra (brightest in O)
+      #   as small as possible to avoid picking up more than one spectrum
+        row_o = np.zeros(2,dtype=int)
+        row_o[0] = np.argmax(np.median(sci_orc[0,:,(2*cols/5):(3*cols/5)],axis=1)).astype(int)
+        lam_c = hdul['WAV'].data[0,row_o[0]]
+        rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
+        rcenter_o = (np.array([rows,0]) +   \
+            np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
+        row_o[1] = rcenter_o[1] + row_o[0] - rcenter_o[0]
+        drow = int(round(4*xtrwindow+0.01*dc*cbin)/rbin)   #  1% allowed tilt 
+
+        row_odR = (row_o[:,None,None] +  \
+            (rpix_oc[:,c_d]-rpix_oc[:,cols/2][:,None])[:,:,None]/rbin + np.arange(-drow,drow)).astype(int)
+
+        row_od = np.zeros((2,2))
+        for o,d in np.ndindex(2,2):
+            sci_Rc = sci_orc[o][row_odR[o,d]] 
+            row_od[o,d] = np.median(sci_Rc[:,col_dC[d]].sum(axis=1).argsort()[-17:])
+
+        yoff_o = rbin*(row_o - rcenter_o)/8. 
+        tilt_i[i] = (row_od.mean(axis=0)[0]-row_od.mean(axis=0)[1])*float(cols)/float(dc)
+        print img,(": brtest object at %6.1f arcsec, tilt: %3i" % (yoff_o[0],tilt_i[i]))
+        print >>log,img,(": brtest object at %6.1f arcsec, tilt: %3i" % (yoff_o[0],tilt_i[i]))
 
     if filestocorrect:
+        if ((yoff_o.min() < locatewindow[0]) | (yoff_o.max() > locatewindow[1])):
+            print "\nNOTE: science locate window may not contain brightest object\n"
+            print >>log,"\nNOTE: science locate window may not contain brightest object\n"
         tilt = np.median(tilt_i[~np.isnan(tilt_i)])
-        print "Median image tilt (cw,total,pixels): ",tilt
-        print >>log,"Median image tilt (cw,total,pixels): ",tilt
+        print "Median image tilt (cw,total,bins): ",tilt
+        print >>log,"Median image tilt (cw,total,bins): ",tilt
         log.flush
         
     # straighten out the spectra
         for img in infilelist:
-#            if (os.path.exists('c' + img)): continue
+            if (useoldc & os.path.exists('c' + img)): continue
             hdu=correct_files(pyfits.open(img),tilt=tilt)
-            hdu.writeto('c' + img, clobber=True)
+            hdu.writeto('c' + img, overwrite=True)
             print 'c' + img
             print >>log,'c' + img
 
     infilelist = [ 'c'+file for file in infilelist ]
 
     for img in infilelist:
-        hdu = pyfits.open(img)
-        if hdu[0].header['LAMPID'].strip() != 'NONE': continue
-        ybin = int(hdu[0].header['CCDSUM'].split(' ')[1])
-        dy = int(dyasec*(8/ybin))        
-        yo_o = np.zeros(2,dtype=int)
-        yo_o[0] = np.median(hdu[1].data[0].sum(axis=1).argsort()[-9:]) + yoffo
-        yo_o[1] = np.median(hdu[1].data[1].sum(axis=1).argsort()[-9:]) + yoffo*1.0075  # allow for magnification
+        hdul = pyfits.open(img)
+        if hdul[0].header['LAMPID'].strip() != 'NONE': continue
+        sci_orc = hdul['SCI'].data
+        rows, cols = sci_orc[0].shape
+        cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
 
+      # find row center of O and E
+        hduw = pyfits.open(img[1:])                                         # use wavmap from wm (cwm messed up)                                      
+        wave_orc = hduw['WAV'].data           
+        lam_c = wave_orc[0,rows/2]
+        rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
+        rcenter_o = (np.array([rows,0]) +   \
+            np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
+        drow_d = (np.round(8*np.array(locatewindow)/rbin)).astype(int)
+        sci_or = sci_orc.mean(axis=2)
+        droff = 0.
+                                    
+        if docomp:                         # for comp, offset by row offset of brtest O outside locate window
+            userow_r =  np.in1d(np.arange(rows),(rcenter_o[0] + np.arange(*drow_d)),invert=True)
+            rlist = np.where(userow_r)[0]
+            droff = rlist[np.argmax(sci_or[0,userow_r])] - rcenter_o[0]
 
-    # establish the wavelength range to be used
-        ys, xs = hdu[1].data.shape[1:]
-        hduw = pyfits.open(img[1:])                                     # use wavmap from wm (cwm messed up)                                      
-        wave_oyx = hduw[4].data                                              
-        wbin = wave_oyx[0,yo_o[0],xs/2]-wave_oyx[0,yo_o[0],xs/2-1]      # bin to nearest power of 2 angstroms          
+        row_o = np.zeros(2,dtype=int)
+        for o in (0,1):
+            userow_r =  np.in1d(np.arange(rows),(rcenter_o[o] + np.arange(*drow_d) + droff))
+            rlist = np.where(userow_r)[0]
+            row_o[o] = rlist[0] + np.median(sci_or[o][rlist].argsort()[-17:])
+
+      # establish the wavelength range to be used
+        wbin = wave_orc[0,row_o[0],cols/2]-wave_orc[0,row_o[0],(cols/2-1)]   # bin to nearest power of 2 angstroms          
         wbin = 2.**(np.rint(np.log2(wbin)))                                 
-        wmin_ox = wave_oyx.max(axis=1)                                     
-        wmin = wmin_ox[wmin_ox>0].reshape((2,-1)).min(axis=1).max()     # ignore wavmap 0 values        
-        wmax = wave_oyx[:,yo_o].reshape((2,-1)).max(axis=1).min()       # use wavs that are in both beams          
-        wmin = (np.ceil(wmin/wbin)+0.5)*wbin                            # note: sc extract uses bin edges                                
-        wmax = (np.floor(wmax/wbin)-0.5)*wbin                               
+        wmin_oc = wave_orc.max(axis=1)                                     
+        wmin = wmin_oc[wmin_oc>0].reshape((2,-1)).min(axis=1).max()          # ignore wavmap 0 values        
+        wmax = wave_orc[:,row_o].reshape((2,-1)).max(axis=1).min()           # use wavs that are in both beams          
+        wmin = (np.ceil(wmin/wbin)+1)*wbin                       
+        wmax = (np.floor(wmax/wbin)-1)*wbin 
+        drow = int(4*xtrwindow/rbin)
+        yoff_o = rbin*(row_o - rcenter_o)/8.                     
 
         o = 0 
-        y1 = yo_o[o] - dy
-        y2 = yo_o[o] + dy        
-        data = hdu[1].data[o]
-        var = hdu[2].data[o]
-        mask = hdu[3].data[o]
-        wave = wave_oyx[o]
-        w, fo, vo, bo = extract(data, var, mask, wave, y1, y2, wmin, wmax, wbin)
+        row1 = row_o[o] - drow
+        row2 = row_o[o] + drow 
+        data = hdul['SCI'].data[o]
+        var = hdul['VAR'].data[o]
+        bpm = hdul['BPM'].data[o]
+        wave = wave_orc[o]
+
+        w, fo, vo, co, bo = extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin)
 
         o = 1
-        y1 = yo_o[o] - dy
-        y2 = yo_o[o] + dy
-        data = hdu[1].data[o]
-        var = hdu[2].data[o]
-        mask = hdu[3].data[o]
-        wave = wave_oyx[o]
-        w, fe, ve, be = extract(data, var, mask, wave, y1, y2, wmin, wmax, wbin)
+        row1 = row_o[o] - drow
+        row2 = row_o[o] + drow   
+        data = hdul['SCI'].data[o]
+        var = hdul['VAR'].data[o]
+        bpm = hdul['BPM'].data[o]
+        wave = wave_orc[o]
+
+        w, fe, ve, ce, be = extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin)
     
         sci_list = [[fo], [fe]]
         var_list = [[vo], [ve]]
+        covar_list = [[co], [ce]]
         bad_list = [[bo], [be]]
-   
-        write_spectra(w, sci_list, var_list, bad_list,  hdu[0].header, wbin, 'e' + img)
 
-        print 'e'+img,"  yo,ye,dy: ",yo_o,dy  
-        print >>log, 'e'+img," yo,ye,dy: ",yo_o,dy
+        outfile = 'e'+img
+        if docomp:
+            outfile = outfile.split('P')[0]+'P_comp_'+outfile.split('P')[1]
+            hdul[0].header['OBJECT'] = 'COMP_'+hdul[0].header['OBJECT']
+        write_spectra(w, sci_list, var_list, covar_list, bad_list,  hdul[0].header, wbin, outfile)
+
+        print outfile,("  dyo,dye: %6.1f %6.1f arcsec" % tuple(yoff_o))
+        print >>log, (outfile," dyo,dye: %6.1f %6.1f arcsec" % tuple(yoff_o))
         log.flush
 
-def extract(data, var, mask, wave, y1, y2, wmin, wmax, wbin):
+    return
+
+def extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin):
     """Extract the spectra
 
     Parameters
     ----------
-    data: numpy.ndarray
+    data: _rc numpy.ndarray
         Flux data for spectra
 
-    var: numpy.ndarray
+    var: _rc numpy.ndarray
         variance data for spectra
 
-    mask: numpy.ndarray
+    mask: _rc numpy.ndarray
         mask data for spectra
 
-    wave: numpy.ndarray
+    wave: _rc numpy.ndarray
         wavelength map for spectra
 
    Returns
    -------
     
     """
-    w = np.arange(wmin, wmax, wbin)
-    y0 = int((y1+y2)/2)
-    wmask = ((wave[y0] > wmin) & (wave[y0] < wmax))
+    wave_W = np.arange(wmin, wmax, wbin)                    # _W = resampled wavelength bin edge
+    Waves = wave_W.shape[0]
+    row0 = int((row1+row2)/2)
+    wmask_c = ((wave[row0] > wmin) & (wave[row0] < (wmax+wbin)))   
+    wave_C = wave[row0,wmask_c]                             # _C = original bin centers within wavelength limits
+    cmin = np.where(wmask_c)[0][0]                          # column c of C=0
+    dwave_C = wave_C[1:]-wave_C[:-1]
+    dwave_C = np.append(dwave_C,dwave_C[-1])
+    dwavpoly = np.polyfit(wave_C-wave_C.mean(),dwave_C-dwave_C.mean(),3)
+    binrat_W = (np.polyval(dwavpoly,wave_W-wave_C.mean()) + dwave_C.mean())/wbin   # old/new bin widths 
 
-    #compute correction to preserve flux
-    Wave = wave[y0,wmask]
-    dWave = Wave[1:]-Wave[:-1]
-    dWave = np.append(dWave,dWave[-1])
-    dwavpoly = np.polyfit(Wave-Wave.mean(),dWave-dWave.mean(),3)
-    fluxcor = (np.polyval(dwavpoly,w-Wave.mean()) + dWave.mean())/wbin
+    C_W = np.zeros(Waves).astype(int)                       # closest column for each wavelength bin
+    for W in range(Waves): C_W[W] = np.where(wave_C > (wave_W[W]))[0][0] -1
+
+    binoff_W = (wave_W - wave_C[C_W])/(wbin*binrat_W)       # offset in columns of closest wavelength bin centers  
+    binfrac_dW = np.zeros((3,Waves))
+    for d in (-1,0,1):                                      # contribution of nearest old bins to new one
+        binfrac_dW[d+1][1:-1] = (np.minimum(wave_W[1:-1]+wbin/2.,wave_C[C_W+d][1:-1]+dwave_C[C_W+d][1:-1]/2.) -    \
+            np.maximum(wave_W[1:-1]-wbin/2.,wave_C[C_W+d][1:-1]-dwave_C[C_W+d][1:-1]/2.)) / dwave_C[C_W+d][1:-1]
+    binfrac_dW[binfrac_dW < 0.] = 0.
 
     #estimate the sky
-    s = np.zeros_like(w)
+    sky_W = np.zeros_like(wave_W)
     count = 0
-    dy = y2-y1
-    for y in range(y1-3*dy, y1-2*dy) + range(y2+2*dy, y2+3*dy):
-        xmask = (wmask & (mask[y]==0))
-        s += np.interp(w, wave[y, xmask], data[y, xmask])
+    drow = row2-row1
+    Rows = 2*drow
+    sky_RW = np.zeros((Rows,Waves))
+    R = -1
+    for r in range(row1-3*drow, row1-2*drow) + range(row2+2*drow, row2+3*drow):
+        xmask_c = (wmask_c & (bpm[r]==0))
+        R += 1
+        sky_RW[R] = np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c])
+        sky_W += np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c])
         count += 1
-    s = s / count
+    sky_W = sky_W / count
 
     # extract the spectra
-    f = np.zeros_like(w)
-    v = np.zeros_like(w)
-    b = np.zeros_like(w).astype(int)
-    for y in range(y1, y2):
-        xmask = (wmask & (mask[y]==0))
-        f += np.interp(w, wave[y, xmask], data[y, xmask]) - s
-        # not exactly correct but estimate
-        v += np.interp(w, wave[y, xmask], var[y, xmask])
-        b += (np.interp(w, wave[y], xmask.astype(float)) < 0.5).astype(int)
+    f_W = np.zeros_like(wave_W)
+    v_W = np.zeros_like(wave_W)
+    cov_W = np.zeros_like(wave_W)
+    b_W = np.zeros_like(wave_W).astype(int)
 
-    f /= fluxcor
-    v /= fluxcor**2
-    b = (b > 0.25*(y2-y1+1)).astype('uint8')        # wavelength is bad if > 25% spectrum bad
+    for r in range(row1, row2):
+        xmask_c = (wmask_c & (bpm[r]==0))
+        f_W += np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c]) - sky_W
+        dv_W = (binfrac_dW**2*var[r,C_W+cmin][None,:]).sum(axis=0)        
+        v_W += dv_W
+        cov_W[:-1] += dv_W[:-1]*binfrac_dW[1,:-1]*binfrac_dW[2,1:]
+        b_W += (np.interp(wave_W, wave[r, wmask_c], xmask_c[wmask_c].astype(float)) < 0.5).astype(int)
 
-    return w, f, v, b
+    f_W /= binrat_W
+    b_W = ((b_W > 0.25*(row2-row1+1)) | (f_W == 0.) | (v_W == 0.)).astype('uint8')    # bad if 0 or > 25% spectrum bad
 
-def write_spectra(wave, sci_ow, var_ow, badbin_ow, header, wbin, outfile):
+    return wave_W, f_W, v_W, cov_W, b_W
+
+def write_spectra(wave, sci_ow, var_ow, covar_ow, badbin_ow, header, wbin, outfile):
     """Write out the spectra in the correct format
 
     """
     header['VAREXT'] = 2
-    header['BPMEXT'] = 3
-    header['CRVAL1'] = wave[0]+wbin/2.  # this needs to be fixed
+    header['COVEXT'] = 3
+    header['BPMEXT'] = 4
+    header['CRVAL1'] = wave[0]
     header['CRVAL2'] = 0
-    header['CDELT1'] = wbin             # this needs to be fixed
+    header['CDELT1'] = wbin             
     header['CTYPE1'] = 'Angstroms'
     hduout = pyfits.PrimaryHDU(header=header)
     hduout = pyfits.HDUList(hduout)
@@ -185,7 +274,8 @@ def write_spectra(wave, sci_ow, var_ow, badbin_ow, header, wbin, outfile):
     hduout.append(pyfits.ImageHDU(data=sci_ow, header=header, name='SCI'))
     header.set('SCIEXT',1,'Extension for Science Frame',before='VAREXT')
     hduout.append(pyfits.ImageHDU(data=var_ow, header=header, name='VAR'))
+    hduout.append(pyfits.ImageHDU(data=covar_ow, header=header, name='COV'))
     hduout.append(pyfits.ImageHDU(data=badbin_ow, header=header, name='BPM'))
 
-    hduout.writeto(outfile,clobber=True,output_verify='warn')
+    hduout.writeto(outfile,overwrite=True,output_verify='warn')
 

--- a/scripts/specpolfinalstokes.py
+++ b/scripts/specpolfinalstokes.py
@@ -13,17 +13,22 @@ import numpy as np
 from astropy.io import fits as pyfits
 
 from scipy.interpolate import interp1d
+from scipy import linalg as la
+from scipy.stats import norm
 from pyraf import iraf
 from iraf import pysalt
 from saltobslog import obslog
 from saltsafelog import logging
 
+import warnings
+# warnings.simplefilter("error")
+
 polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
 datadir = polsaltdir+'/polsalt/data/'
 sys.path.extend((polsaltdir+'/polsalt/',))
 
+import specpolview as spv
 from specpolutils import datedfile, datedline
-from specpolview import wtavstokes, printstokes
 from specpolflux import specpolflux
 
 np.set_printoptions(threshold=np.nan)
@@ -64,8 +69,10 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
         patternpairs[p.split()[0]]=(len(p.split())-3)/2
         patternstokes[p.split()[0]]=int(p.split()[1])
 
+    if len(glob.glob('specpol*.log')): logfile=glob.glob('specpol*.log')[0]
     with logging(logfile, debug) as log:
-        
+
+        log.message('specpolfinalstokes version: 20171226', with_header=False)          
     # organize data using names. 
     #   allrawlist = infileidx,object,config,wvplt,cycle for each infile.
         obsdict=obslog(infilelist)
@@ -153,6 +160,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
         #   one entry for each set of cycles that needs to be combined (i.e, one for each wvplt)
             stokes_jSw = np.zeros((rawstokes,2,wavs)) 
             var_jSw = np.zeros_like(stokes_jSw)
+            covar_jSw = np.zeros_like(stokes_jSw)
             bpm_jSw = np.zeros_like(stokes_jSw).astype(int)
             comblist = []
 
@@ -171,6 +179,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                 wppat = pyfits.getheader(infilelist[i])['WPPATERN'].upper()
                 stokes_jSw[j] = pyfits.open(infilelist[i])['SCI'].data.reshape((2,-1))
                 var_jSw[j] = pyfits.open(infilelist[i])['VAR'].data.reshape((2,-1))
+                covar_jSw[j] = pyfits.open(infilelist[i])['COV'].data.reshape((2,-1))
                 bpm_jSw[j] = pyfits.open(infilelist[i])['BPM'].data.reshape((2,-1))
 
             # apply telescope zeropoint calibration, q rotated to raw coordinates
@@ -178,7 +187,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     trkrho = pyfits.getheader(infilelist[i])['TRKRHO']
                     dpatelraw_w = -(22.5*float(wvplt[1]) + hpar_w + trkrho) 
                     rawtel0_sw =    \
-                        specpolrotate(tel0_sw,np.zeros((3,wavs)),dpatelraw_w,normalized=True)[0]
+                        specpolrotate(tel0_sw,0,0,dpatelraw_w,normalized=True)[0]
                     rawtel0_sw[:,okcal_w] *= heff_w[okcal_w]
                     stokes_jSw[j,1,okcal_w] -= stokes_jSw[j,0,okcal_w]*rawtel0_sw[0,okcal_w]     
                 if cycles==1:
@@ -187,9 +196,12 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     comblist[-1] = (j,object,config,wvplt,cycles,wppat)
 
         # combine multiple cycles as necessary.  Absolute stokes is on a per cycle basis.
+        # polarimetric combination on normalized stokes basis 
+        #  to avoid coupling mean syserr into polarimetric spectral features
             combstokess = len(comblist)
             stokes_kSw = np.zeros((combstokess,2,wavs)) 
             var_kSw = np.zeros_like(stokes_kSw)
+            covar_kSw = np.zeros_like(stokes_kSw)
             cycles_kw = np.zeros((combstokess,wavs)).astype(int)
             chi2cycle_kw = np.zeros((combstokess,wavs))
             badcyclechi_kw = np.zeros((combstokess,wavs),dtype=bool)
@@ -204,34 +216,46 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
 
             obsobject = ''
             obsconfig = ''
+            chi2cycle_j = np.zeros(rawstokes)
+            syserrcycle_j = np.zeros(rawstokes)
+            iscull_jw = np.zeros((rawstokes,wavs),dtype=bool)
+            stokes_kSw = np.zeros((combstokess,2,wavs))
+            var_kSw = np.zeros_like(stokes_kSw)
             nstokes_kw = np.zeros((combstokess,wavs))
             nvar_kw = np.zeros_like(nstokes_kw)
-            chi2cycle_j = np.zeros(rawstokes)
-            iscull_jw = np.zeros((rawstokes,wavs),dtype=bool)
+            ncovar_kw = np.zeros_like(nstokes_kw)
             chi2cyclenet_k = np.zeros(combstokess)
+            syserrcyclenet_k = np.zeros(combstokess)
 
             for k in range(combstokess):         
                 j,object,config,wvplt,cycles,wppat = comblist[k]
                 jlistk.append(range(j-cycles+1,j+1))                                
                 Jlistk.append([int(rawlist[jj][4])-1 for jj in range(j-cycles+1,j+1)])  # J = cycle-1, counting from 0        
-                cycles_kw[k] =  (1-bpm_jSw[j-cycles+1:j+1,0]).sum(axis=0).astype(int)
+                nstokes_Jw = np.zeros((cycles,wavs))
+                nvar_Jw = np.zeros((cycles,wavs))
+                ncovar_Jw = np.zeros((cycles,wavs))
+                bpm_Jw = np.zeros((cycles,wavs))
+                ok_Jw = np.zeros((cycles,wavs),dtype=bool)
 
-            # compute chisq vs wavelength  for multiple cycles.  Compare each cycle with every other cycle (dof=1).
-            # bad wavelengths flagged for P < .05% (1/2000): chisq  > 12.2
+                for J,j in enumerate(jlistk[k]):
+                    bpm_Jw[J] = bpm_jSw[j,0]
+                    ok_Jw[J] = (bpm_Jw[J] ==0)
+                    nstokes_Jw[J][ok_Jw[J]] = stokes_jSw[j,1][ok_Jw[J]]/stokes_jSw[j,0][ok_Jw[J]]
+                    nvar_Jw[J][ok_Jw[J]] = var_jSw[j,1][ok_Jw[J]]/(stokes_jSw[j,0][ok_Jw[J]])**2
+                    ncovar_Jw[J][ok_Jw[J]] = covar_jSw[j,1][ok_Jw[J]]/(stokes_jSw[j,0][ok_Jw[J]])**2
+
+            # Culling:  for multiple cycles, compare each cycle with every other cycle (dof=1).
+            # bad wavelengths flagged for P < .02% (1/2000): chisq  > 13.8  (chi2.isf(q=.0002,df=1))
             # for cycles>2, vote to cull specific pair/wavelength, otherwise cull wavelength
-                chi2lim = 12.2 
+
+                cycles_kw[k] =  (1-bpm_Jw).sum(axis=0).astype(int)
                 okchi_w = (cycles_kw[k] > 1)
+                chi2lim = 13.8 
                 havecyclechi_k[k] = okchi_w.any()
                 if cycles > 1:
-                    nstokes_Jw = np.zeros((cycles,wavs))
-                    nvar_Jw = np.zeros((cycles,wavs))
+                    ok_Jw[J] = okchi_w & (bpm_Jw[J] ==0)
                     chi2cycle_JJw = np.zeros((cycles,cycles,wavs))
                     badcyclechi_JJw = np.zeros((cycles,cycles,wavs))
-                    ok_Jw = np.zeros((cycles,wavs),dtype=bool)
-                    for J,j in enumerate(jlistk[k]):
-                        ok_Jw[J] = okchi_w & (bpm_jSw[j,0] ==0)
-                        nstokes_Jw[J][ok_Jw[J]] = stokes_jSw[j,1][ok_Jw[J]]/stokes_jSw[j,0][ok_Jw[J]]
-                        nvar_Jw[J][ok_Jw[J]] = var_jSw[j,1][ok_Jw[J]]/(stokes_jSw[j,0][ok_Jw[J]])**2
                     ok_JJw = ok_Jw[:,None,:] & ok_Jw[None,:,:] 
                     nstokes_JJw = nstokes_Jw[:,None] - nstokes_Jw[None,:]
                     nvar_JJw = nvar_Jw[:,None] + nvar_Jw[None,:]                           
@@ -256,9 +280,12 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                         for j in jlistk[k]:
                             iscull_jw[j] = badcyclechiall_w             # for reporting
                             bpm_jSw[j][:,badcyclechiall_w] = 1
+                    for J,j in enumerate(jlistk[k]):
+                        bpm_Jw[J] = bpm_jSw[j,0]
 
                     if debug:
                         obsname = object+"_"+config 
+                        ok_Jw = okchi_w[None,:] & (bpm_Jw ==0)
                         np.savetxt(obsname+"_nstokes_Jw_"+str(k)+".txt",np.vstack((wav_w,ok_Jw.astype(int),    \
                             nstokes_Jw,nvar_Jw)).T, fmt="%8.2f "+cycles*"%3i "+cycles*"%10.6f "+cycles*"%10.12f ")                        
                         np.savetxt(obsname+"_chi2cycle_iw_"+str(k)+".txt",np.vstack((wav_w,okchi_w.astype(int),    \
@@ -273,31 +300,61 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                 else:
                     obslist[-1][4] +=1
 
-                cycles_kw[k] =  (1-bpm_jSw[j-cycles+1:j+1,0]).sum(axis=0).astype(int)
+          # Now combine cycles, using normalized stokes to minimize systematic errors
+
+            # first normalize cycle members J at wavelengths where all cycles have data:
+                cycles_kw[k] =  (1-bpm_Jw).sum(axis=0).astype(int)
                 ok_w = (cycles_kw[k] > 0)
-                stokes_kSw[k] = stokes_jSw[j-cycles+1:j+1].sum(axis=0)
-                var_kSw[k] = var_jSw[j-cycles+1:j+1].sum(axis=0)
-                stokes_kSw[k,:,ok_w] /= cycles_kw[k,None,ok_w] 
-                var_kSw[k,:,ok_w] /= cycles_kw[k,None,ok_w]**2
-                nstokes_kw[k][ok_w] = stokes_kSw[k,1][ok_w]/stokes_kSw[k,0][ok_w]
-                nvar_kw[k][ok_w] = var_kSw[k,1][ok_w]/stokes_kSw[k,0][ok_w]**2              
+                okall_w = (cycles_kw[k] == cycles)
+                normint_J = np.array(stokes_jSw[jlistk[k],0][:,okall_w].sum(axis=1))
+                normint_J /= np.mean(normint_J)
+                stokes_JSw = stokes_jSw[jlistk[k]]/normint_J[:,None,None]
+                var_JSw = var_jSw[jlistk[k]]/normint_J[:,None,None]**2
+                covar_JSw = covar_jSw[jlistk[k]]/normint_J[:,None,None]**2
 
-            # compute mean chisq for each pair having multiple cycles (after culling)  
-                okchi_w = (cycles_kw[k] > 1)
+                for J in range(cycles):
+                    okJ_w = ok_w & (bpm_Jw[J] ==0)
+                  # average the intensity
+                    stokes_kSw[k,0,okJ_w] += stokes_JSw[J,0,okJ_w]/cycles_kw[k][okJ_w]
+                    var_kSw[k,0,okJ_w] += var_JSw[J,0,okJ_w]/cycles_kw[k][okJ_w]**2
+                    covar_kSw[k,0,okJ_w] += covar_JSw[J,0,okJ_w]/cycles_kw[k][okJ_w]**2
+                  # now the normalized stokes
+                    nstokes_kw[k][okJ_w] += (stokes_JSw[J,1][okJ_w]/stokes_JSw[J,0][okJ_w])/cycles_kw[k][okJ_w]
+                    nvar_kw[k][okJ_w] += (var_JSw[J,1][okJ_w]/stokes_JSw[J,0][okJ_w]**2)/cycles_kw[k][okJ_w]**2
+                    ncovar_kw[k][okJ_w] += (covar_JSw[J,1][okJ_w]/stokes_JSw[J,0][okJ_w]**2)/cycles_kw[k][okJ_w]**2
+                stokes_kSw[k,1] = nstokes_kw[k]*stokes_kSw[k,0]
+                var_kSw[k,1] = nvar_kw[k]*stokes_kSw[k,0]**2 
+                covar_kSw[k,1] = ncovar_kw[k]*stokes_kSw[k,0]**2         
+                if debug:
+                    obsname = object+"_"+config 
+                    np.savetxt(obsname+"_stokes_kSw_"+str(k)+".txt",np.vstack((wav_w,ok_w.astype(int),    \
+                            stokes_kSw[k])).T, fmt="%8.2f %3i "+2*"%12.3f ")                    
+
+            # compute mean chisq for each pair having multiple cycles  
                 if cycles > 1:
-                    ok_Jw = np.zeros((cycles,wavs),dtype=bool)
-                    chi2cycle_Jw = np.zeros((cycles,wavs))
-                    for J,j in enumerate(jlistk[k]):
-                        ok_Jw[J] = okchi_w & (bpm_jSw[j,0] ==0)
-                        chi2cycle_Jw[J][ok_Jw[J]] = (nstokes_Jw[J][ok_Jw[J]] - nstokes_kw[k][ok_Jw[J]])**2/  \
-                            (nvar_Jw[J][ok_Jw[J]] - nvar_kw[k][ok_Jw[J]])
-                        chi2cycle_j[j] = np.mean(chi2cycle_Jw[J,ok_Jw[J]])                                              
-                    chi2cyclenet_k[k] = np.mean(chi2cycle_Jw[:,okchi_w])
+                    nstokeserr_Jw = np.zeros((cycles,wavs))
+                    nerr_Jw = np.zeros((cycles,wavs))
+                    for J in range(cycles):
+                        okJ_w = ok_w & (bpm_Jw[J] ==0)
+                        nstokes_Jw[J][okJ_w] = stokes_JSw[J,1][okJ_w]/stokes_JSw[J,0][okJ_w]
+                        nvar_Jw[J][okJ_w] = var_JSw[J,1][okJ_w]/(stokes_JSw[J,0][okJ_w])**2                    
+                        nstokeserr_Jw[J] = (nstokes_Jw[J] - nstokes_kw[k])
+                        nvar_w = nvar_Jw[J] - nvar_kw[k]
+                        okall_w &= (nvar_w > 0.)
+                        nerr_Jw[J,okall_w] = np.sqrt(nvar_w[okall_w])
 
-                    if debug:
-                        obsname = object+"_"+config 
-                        np.savetxt(obsname+"_nstokes_kw_"+str(k)+".txt",np.vstack((wav_w,nstokes_kw[k],nvar_kw[k])).T,    \
-                             fmt="%8.2f %10.6f %10.12f ") 
+                    nstokessyserr_J = np.average(nstokeserr_Jw[:,okall_w],weights=1./nerr_Jw[:,okall_w],axis=1)
+                    nstokeserr_Jw -= nstokessyserr_J[:,None]                   
+                    for J,j in enumerate(jlistk[k]):
+                        loc,scale = norm.fit(nstokeserr_Jw[J,okall_w]/nerr_Jw[J,okall_w])
+                        chi2cycle_j[j] = scale**2
+                        syserrcycle_j[j] = nstokessyserr_J[J]
+                    chi2cyclenet_k[k] = chi2cycle_j[jlistk[k]].mean()
+                    syserrcyclenet_k[k] = np.sqrt((syserrcycle_j[jlistk[k]]**2).sum())/len(jlistk[k])
+
+                    if debug:   
+                        obsname = object+"_"+config
+                        chisqanalysis(obsname,nstokeserr_Jw,nerr_Jw,okall_w)
                                                                      
         # for each obs combine raw stokes, apply efficiency and PA calibration as appropriate for pattern, and save
             obss = len(obslist)
@@ -332,7 +389,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     obsname += "_"
                     j0 = comblist[k_p[p]][0] - cycles_p[p] + 1
                     for j in range(j0,j0+cycles_p[p]): obsname+=rawlist[j][4][-1]
-                log.message("\n  Observation: %s" % obsname, with_header=False)
+                log.message("\n  Observation: %s  Date: %s" % (obsname,dateobs), with_header=False)
                 finstokes = patternstokes[wppat]   
 
                 if pairs != patpairs:
@@ -345,6 +402,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
 
                 stokes_Fw = np.zeros((finstokes,wavs))
                 var_Fw = np.zeros_like(stokes_Fw)
+                covar_Fw = np.zeros_like(stokes_Fw)
 
             # normalize pairs in obs at wavelengths _W where all pair/cycles have data:
                 okall_w = okcal_w & (cycles_pw[plist] == cycles_p[plist,None]).all(axis=0)     
@@ -352,10 +410,12 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                 normint_K /= np.mean(normint_K)
                 stokes_kSw[klist] /= normint_K[:,None,None]
                 var_kSw[klist] /= normint_K[:,None,None]**2
+                covar_kSw[klist] /= normint_K[:,None,None]**2
 
             # first, the intensity
                 stokes_Fw[0] = stokes_kSw[klist,0].sum(axis=0)/pairs
-                var_Fw[0] = var_kSw[klist,0].sum(axis=0)/pairs**2        
+                var_Fw[0] = var_kSw[klist,0].sum(axis=0)/pairs**2 
+                covar_Fw[0] = covar_kSw[klist,0].sum(axis=0)/pairs**2         
             # now, the polarization stokes
                 if wppat.count('LINEAR'):
                     var_Fw = np.vstack((var_Fw,np.zeros(wavs)))           # add QU covariance
@@ -365,6 +425,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                         bpm_Fw = np.repeat((np.logical_not(ok_w))[None,:],finstokes,axis=0)
                         stokes_Fw[1:,ok_w] = stokes_kSw[klist,1][:,ok_w]*(stokes_Fw[0,ok_w]/stokes_kSw[klist,0][:,ok_w])
                         var_Fw[1:3,ok_w] = var_kSw[klist,1][:,ok_w]*(stokes_Fw[0,ok_w]/stokes_kSw[klist,0][:,ok_w])**2
+                        covar_Fw[1:,ok_w] = covar_kSw[klist,1][:,ok_w]*(stokes_Fw[0,ok_w]/stokes_kSw[klist,0][:,ok_w])**2
 
                     elif wppat=='LINEAR-HI':
                      # for Linear-Hi, must go to normalized stokes in order for the pair combination to cancel systematic errors
@@ -376,8 +437,10 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                         bpm_Fw = np.repeat((np.logical_not(ok_w))[None,:],finstokes,axis=0)
                         stokespri_pw = np.zeros((patpairs,wavs))
                         varpri_pw = np.zeros_like(stokespri_pw)
+                        covarpri_pw = np.zeros_like(stokespri_pw)
                         stokespri_pw[plist] = nstokes_kw[klist]
                         varpri_pw[plist] = nvar_kw[klist]
+                        covarpri_pw[plist] = ncovar_kw[klist]
                         haveraw_pw = (cycles_pw > 0)
                         pricof_ppw = np.identity(patpairs)[:,:,None]*haveraw_pw[None,:,:]                      
 
@@ -394,6 +457,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                                     seccof2_pp[:,:,None]*onlysec2_pw[:,None,:] 
                         stokessec_pw = (seccof_ppw*stokespri_pw[:,None,:]).sum(axis=0)
                         varsec_pw = (seccof_ppw**2*varpri_pw[:,None,:]).sum(axis=0)
+                        covarsec_pw = (seccof_ppw**2*covarpri_pw[:,None,:]).sum(axis=0)
 
                         havesec_pw = (havesecb_pw | onlysec1_pw | onlysec2_pw)
                         prisec_pw = (haveraw_pw & havesec_pw)
@@ -406,6 +470,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     # now do the combination
                         stokes_pw = (cof_ppw*stokespri_pw[None,:,:]).sum(axis=1)
                         var_pw = (cof_ppw**2*varpri_pw[None,:,:]).sum(axis=1)
+                        covar_pw = (cof_ppw**2*covarpri_pw[None,:,:]).sum(axis=1)
                         covarprisec_pw = 0.5*varpri_pw*np.logical_or(onlysec1_pw,onlysec2_pw)
                         covarqu_w = (cof_ppw[0]*cof_ppw[2]*varpri_pw).sum(axis=0)
 
@@ -414,17 +479,23 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                         badlinhichi_w = np.zeros(wavs)
                         havelinhichi_p = prisec_pw.any(axis=1)
                         linhichis = havelinhichi_p.sum()
-
                         chi2linhi_pw[prisec_pw] = ((stokespri_pw[prisec_pw] - stokessec_pw[prisec_pw])**2 / \
                             (varpri_pw[prisec_pw] + varsec_pw[prisec_pw] - 2.*covarprisec_pw[prisec_pw]))
 
                         q3_p = np.percentile(chi2linhi_pw[:,okall_w].reshape((4,-1)),75,axis=1)
                         badlinhichi_w[ok_w] = ((chi2linhi_pw[:,ok_w] > (chifence_d[2]*q3_p)[:,None])).any(axis=0)               
-                        ok_w &= np.logical_not(badlinhichi_w)                        
-
+                        ok_w &= np.logical_not(badlinhichi_w)
+                        okall_w &= np.logical_not(badlinhichi_w)
                         chi2linhi_p = np.zeros(patpairs)
                         chi2linhi_p[havelinhichi_p] = (chi2linhi_pw[havelinhichi_p][:,ok_w]).sum(axis=1)/    \
-                            (prisec_pw[havelinhichi_p][:,ok_w]).sum(axis=1)
+                            (prisec_pw[havelinhichi_p][:,ok_w]).sum(axis=1)                        
+                        syserrlinhi_pw = np.zeros((patpairs,wavs))
+                        varlinhi_pw = np.zeros((patpairs,wavs))
+                        syserrlinhi_p = np.zeros(patpairs)
+                        syserrlinhi_pw[prisec_pw] = (stokespri_pw[prisec_pw] - stokessec_pw[prisec_pw])
+                        varlinhi_pw[prisec_pw] = varpri_pw[prisec_pw] + varsec_pw[prisec_pw] - 2.*covarprisec_pw[prisec_pw]
+                        syserrlinhi_p[havelinhichi_p] = np.average(syserrlinhi_pw[havelinhichi_p][:,okall_w], \
+                            weights=1./np.sqrt(varlinhi_pw[havelinhichi_p][:,okall_w]),axis=1)
 
                         if debug:
                             np.savetxt(obsname+"_have_pw.txt",np.vstack((wav_w,ok_pw.astype(int),haveraw_pw,havesecb_pw,    \
@@ -437,85 +508,91 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                             np.savetxt(obsname+"_stokes.txt",np.vstack((wav_w,ok_pw.astype(int),stokespri_pw,stokes_pw)).T,    \
                                 fmt="%8.2f  "+4*"%2i "+8*" %10.6f")
                             np.savetxt(obsname+"_var.txt",np.vstack((wav_w,ok_pw.astype(int),varpri_pw,var_pw)).T, \
-                                fmt="%8.2f  "+4*"%2i "+8*"%14.9f ")                      
+                                fmt="%8.2f  "+4*"%2i "+8*"%14.9f ")
+                            np.savetxt(obsname+"_covar.txt",np.vstack((wav_w,ok_pw.astype(int),covarpri_pw,covar_pw)).T, \
+                                fmt="%8.2f  "+4*"%2i "+8*"%14.9f ")                       
                             np.savetxt(obsname+"_chi2linhi_pw.txt",np.vstack((wav_w,stokes_Fw[0],ok_pw.astype(int),   \
                                 chi2linhi_pw)).T,  fmt="%8.2f %10.0f "+4*"%2i "+4*"%10.4f ")
 
                         stokes_Fw[1:] = stokes_pw[[0,2]]*stokes_Fw[0]                        
                         var_Fw[1:3] = var_pw[[0,2]]*stokes_Fw[0]**2
                         var_Fw[3] = covarqu_w*stokes_Fw[0]**2
+                        covar_Fw[1:] = covar_pw[[0,2]]*stokes_Fw[0]**2
                         bpm_Fw = ((bpm_Fw==1) | np.logical_not(ok_w)).astype(int)
 
                 # document chisq results, combine flagoffs, compute mean chisq for observation, combine with final bpm
-
                     if (havecyclechi_p.any() | havelinhichi_p.any()):
-
+                        chi2cyclenet = 0.
+                        syserrcyclenet = 0.
+                        chi2linhinet = 0.
+                        syserrlinhinet = 0.
                         if havecyclechi_p.any():
-                            log.message((14*" "+2*("{:^"+str(7*patpairs)+"}")).format("culled","mean chisq"),   \
-                                with_header=False)
-                            log.message((9*" "+"HW "+2*patpairs*" %6s") % tuple(patwplist+patwplist), with_header=False)
+                            log.message(("\n"+14*" "+"{:^"+str(5*patpairs)+"}{:^"+str(8*patpairs)+"}{:^"+str(6*patpairs)+"}")\
+                                .format("culled","sys %err","mean chisq"), with_header=False)
+                            log.message((9*" "+"HW "+patpairs*" %4s"+patpairs*" %7s"+patpairs*" %5s") \
+                                % tuple(3*patwplist),with_header=False)
                             jlist = sum([jlistk[k] for k in klist],[])
                             Jlist = list(set(sum([Jlistk[k] for k in klist],[])))
                             Jmax = max(Jlist)
                             ok_pJ = np.zeros((patpairs,Jmax+1),dtype=bool)
                             for p in plist: ok_pJ[p][Jlistk[k_p[p]]] = True
+ 
+                            syserrcycle_pJ = np.zeros((patpairs,Jmax+1))
+                            syserrcycle_pJ[ok_pJ] = syserrcycle_j[jlist]
+                            syserrcyclenet_p = np.zeros(patpairs)
+                            syserrcyclenet_p[plist] = syserrcyclenet_k[klist]
+                            syserrcyclenet = np.sqrt((syserrcyclenet_p**2).sum()/patpairs) 
                             chi2cycle_pJ = np.zeros((patpairs,Jmax+1))
-                            chi2cycle_pJ[ok_pJ] = chi2cycle_j[jlist] 
+                            chi2cycle_pJ[ok_pJ] = chi2cycle_j[jlist]
                             chi2cyclenet_p = np.zeros(patpairs)
                             chi2cyclenet_p[plist] = chi2cyclenet_k[klist]
+                            chi2cyclenet = chi2cyclenet_p.sum()/patpairs
                             culls_pJ = np.zeros((patpairs,Jmax+1),dtype=int)
                             culls_pJ[ok_pJ] = iscull_jw[jlist].sum(axis=1)                            
 
                             if cycles_p.max() > 2:
                                 for J in set(Jlist):
-                                    log.message(("   cycle %2i: "+patpairs*"%6i "+patpairs*"%6.2f ") %     \
-                                        ((J+1,)+tuple(culls_pJ[:,J])+tuple(chi2cycle_pJ[:,J])), with_header=False)
+                                    log.message((("   cycle %2i: "+patpairs*"%4i "+patpairs*"%7.3f "+patpairs*"%5.2f ") %     \
+                                        ((J+1,)+tuple(culls_pJ[:,J])+tuple(100.*syserrcycle_pJ[:,J])+tuple(chi2cycle_pJ[:,J]))), \
+                                                with_header=False)
 
                             netculls_p = [iscull_jw[jlistk[k_p[p]]].all(axis=0).sum() for p in range(patpairs)]
-                            chi2_p = chi2cyclenet_p 
-                            log.message(("    net    : "+patpairs*"%6i "+patpairs*"%6.2f ") %     \
-                                 (tuple(netculls_p)+tuple(chi2_p)), with_header=False)
+                            log.message(("    net    : "+patpairs*"%4i "+patpairs*"%7.3f "+patpairs*"%5.2f ") %     \
+                                 (tuple(netculls_p)+tuple(100*syserrcyclenet_p)+tuple(chi2cyclenet_p)), with_header=False)
                         if (havelinhichi_p.any()):
-                            chicount = badlinhichi_w.astype(int).sum()
-                            log.message("   Wavelengths culled by linhi Chisq: %5i\n" % chicount, with_header=False)
-                            log.message((10*" "+"HW "+patpairs*" %6s") % tuple(patwplist), with_header=False) 
-                            chi2_p = chi2linhi_p 
-                            log.message("   Pair Chisq: "+patpairs*"%6.2f " % tuple(chi2_p), with_header=False) 
+                            log.message(("\n"+14*" "+"{:^"+str(5*patpairs)+"}{:^"+str(8*patpairs)+"}{:^"+str(6*patpairs)+"}")\
+                                .format("culled","sys %err","mean chisq"), with_header=False)
+                            log.message((9*" "+"HW "+(4*patpairs/2)*" "+" all"+(4*patpairs/2)*" "+patpairs*" %7s"+patpairs*" %5s") \
+                                % tuple(2*patwplist),with_header=False)
+                            chicount = int(badlinhichi_w.sum())
+                            chi2linhinet = chi2linhi_p.sum()/(havelinhichi_p.sum())
+                            syserrlinhinet = np.sqrt((syserrlinhi_p**2).sum()/(havelinhichi_p.sum()))
+                            log.message(("      Linhi: "+(2*patpairs)*" "+"%3i "+(2*patpairs)*" "+patpairs*"%7.3f "+patpairs*"%5.2f ") % \
+                                ((chicount,)+tuple(100.*syserrlinhi_p)+tuple(chi2linhi_p)), with_header=False)
 
-                # calculate, print estimated systematic error from chisq mean
-                        chi2qudof = chi2_p[chi2_p != 0].mean()
-                        dofs = float(ok_w.sum())
-                        chi2qudoferr = np.sqrt(2./dofs)
-                        syserr = 0.         # estimate systematic error using noncentral chisq distribution
-                        if (chi2qudof - 1.) > 3.*chi2qudoferr:
-                            var_fw = np.zeros_like(var_Fw)
-                            var_fw[:,ok_w] = var_Fw[:,ok_w]/stokes_Fw[0,ok_w]**2
-                            syserr = np.sqrt(dofs*(chi2qudof - 1.)/(1./var_fw[1,ok_w]).sum())
+                        chi2qudof = (chi2cyclenet+chi2linhinet)/(int(chi2cyclenet>0)+int(chi2linhinet>0))
+                        syserr = np.sqrt((syserrcyclenet**2+syserrlinhinet**2)/    \
+                            (int(syserrcyclenet>0)+int(syserrlinhinet>0)))
               
-                        log.message(("\n   Mean Chisq: %6.2f  Estimated sys %%error: %5.2f") % \
-                            (chi2qudof,100.*syserr), with_header=False)
+                        log.message(("\n  Estimated sys %%error: %5.3f%%   Mean Chisq: %6.2f") % \
+                            (100.*syserr,chi2qudof), with_header=False)
 
                     if not HW_Cal_override:
                 # apply hw efficiency, equatorial PA rotation calibration
                         stokes_Fw[1:,ok_w] /= heff_w[ok_w]
                         var_Fw[1:,ok_w] /= heff_w[ok_w]**2
-                        stokes_Fw,var_Fw = specpolrotate(stokes_Fw,var_Fw,eqpar_w)
-
-                # calculate, print means (stokes wtd in norm space by 1/sqrt(mean variance)
-                    wtavstokes_f, wtavvar_f, wtavwav = wtavstokes(stokes_Fw,var_Fw,wav_w) 
-                    wtavstokes_F = np.insert(wtavstokes_f,0,1.)
-                    wtavvar_F = np.insert(wtavvar_f,0,1.)           
-                    printstokes(wtavstokes_F,wtavvar_F,wtavwav,tcenter=np.pi/2.,textfile='tmp.log')
-                    log.message(open('tmp.log').read(), with_header=False)
-                    os.remove('tmp.log')
+                        covar_Fw[1:,ok_w] /= heff_w[ok_w]**2
+                        stokes_Fw,var_Fw,covar_Fw = specpolrotate(stokes_Fw,var_Fw,covar_Fw,eqpar_w)
 
                 # save final stokes fits file for this observation.  Strain out nans.
                     infile = infilelist[rawlist[comblist[k][0]][0]]
                     hduout = pyfits.open(infile)
-                    hduout['SCI'].data = np.nan_to_num(stokes_Fw.astype('float32').reshape((3,1,-1)))
+                    hduout['SCI'].data = np.nan_to_num(stokes_Fw.reshape((3,1,-1)))
                     hduout['SCI'].header['CTYPE3'] = 'I,Q,U'
-                    hduout['VAR'].data = np.nan_to_num(var_Fw.astype('float32').reshape((4,1,-1)))
+                    hduout['VAR'].data = np.nan_to_num(var_Fw.reshape((4,1,-1)))
                     hduout['VAR'].header['CTYPE3'] = 'I,Q,U,QU'
+                    hduout['COV'].data = np.nan_to_num(covar_Fw.reshape((3,1,-1)))
+                    hduout['COV'].header['CTYPE3'] = 'I,Q,U,QU'
 
                     hduout['BPM'].data = bpm_Fw.astype('uint8').reshape((3,1,-1))
                     hduout['BPM'].header['CTYPE3'] = 'I,Q,U'
@@ -525,15 +602,27 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
                     if len(calhistorylist):
                         for line in calhistorylist: hduout[0].header.add_history(line)
 
-                    if chi2_p.shape[0] ==2: 
+                    if (havecyclechi_p.any() | havelinhichi_p.any()): 
                         hduout[0].header['SYSERR'] = (100.*syserr,'estimated % systematic error')
                     
                     outfile = obsname+'_stokes.fits'
-                    hduout.writeto(outfile,clobber=True,output_verify='warn')
+                    hduout.writeto(outfile,overwrite=True,output_verify='warn')
                     log.message('\n    '+outfile+' Stokes I,Q,U', with_header=False)
 
                 # apply flux calibration, if available
-                    specpolflux(outfile,logfile=logfile)
+                    fluxcal_w = specpolflux(outfile,logfile=logfile)
+                    if fluxcal_w.shape[0]>0:
+                        stokes_Fw *= fluxcal_w
+                        var_Fw *= fluxcal_w**2
+                        covar_Fw *= fluxcal_w**2
+
+                # calculate, print means (stokes averaged in unnorm space)
+                    avstokes_f, avvar_f, avwav = spv.avstokes(stokes_Fw,var_Fw[:-1],covar_Fw,wav_w) 
+                    avstokes_F = np.insert(avstokes_f,0,1.)
+                    avvar_F = np.insert(avvar_f,0,1.)           
+                    spv.printstokes(avstokes_F,avvar_F,avwav,tcenter=np.pi/2.,textfile='tmp.log')
+                    log.message(open('tmp.log').read(), with_header=False)
+                    os.remove('tmp.log')
                      
 #               elif wppat.count('CIRCULAR'):  TBS 
 
@@ -544,7 +633,7 @@ def specpolfinalstokes(infilelist,logfile='salt.log',debug=False,  \
     return 
 
 # ------------------------------------
-def specpolrotate(stokes_Sw,var_Sw,par_w,normalized=False):
+def specpolrotate(stokes_Sw,var_Sw,covar_Sw,par_w,normalized=False):
     """ rotate linear polarization in stokes,variance cubes
 
     Parameters
@@ -552,8 +641,10 @@ def specpolrotate(stokes_Sw,var_Sw,par_w,normalized=False):
     stokes_Sw: 2d np array
         _S = I,Q,U,(optional V) unnormalized stokes (size 3, or 4)
         _w = wavelength
-    var_Sw: 2d np array (size 4, or 5)
-        _S = I,Q,U,QU covariance, (optional V) variance for stokes
+    var_Sw: 2d np array (size 4, or 5).  If not an array, ignore errors
+        _S = I,Q,U,QU variance, (optional V) QU covariance for stokes
+    covar_Sw: 2d np array (size 3, or 4)
+        _S = I,Q,U covariance, (optional V) covariance in wavelength for stokes
     par_w: 1d np array (if single float, expand it) 
         PA(degrees) to rotate
     normalized: if True, there is no I
@@ -565,15 +656,86 @@ def specpolrotate(stokes_Sw,var_Sw,par_w,normalized=False):
     Qarg = int(not normalized)
     stokes_Fw = np.copy(stokes_Sw)
     var_Fw = np.copy(var_Sw)
-    if par_w.shape[0]==1: par_w = np.repeat(par_w,stokes_Sw.shape[1])
+    covar_Fw = np.copy(covar_Sw)
+    if (type(par_w) is float):  par_w = np.repeat(par_w,stokes_Sw.shape[1])
+    if (par_w.shape[0]==1):     par_w = np.repeat(par_w,stokes_Sw.shape[1])
     c_w = np.cos(2.*np.radians(par_w))
     s_w = np.sin(2.*np.radians(par_w))
     stokes_Fw[Qarg:] = stokes_Fw[Qarg]*c_w - stokes_Fw[Qarg+1]*s_w ,    \
         stokes_Fw[Qarg]*s_w + stokes_Fw[Qarg+1]*c_w
-    var_Fw[Qarg:Qarg+2] =  var_Fw[Qarg]*c_w**2 + var_Fw[Qarg+1]*s_w**2 ,    \
-        var_Fw[Qarg]*s_w**2 + var_Fw[Qarg+1]*c_w**2
-    var_Fw[Qarg+2] =  c_w*s_w*(var_Fw[Qarg] - var_Fw[Qarg+1]) + (c_w**2-s_w**2)*var_Fw[Qarg+2]
-    return stokes_Fw,var_Fw
+    if (type(var_Sw) == type(stokes_Sw)):
+        var_Fw[Qarg:Qarg+2] =  var_Fw[Qarg]*c_w**2 + var_Fw[Qarg+1]*s_w**2 ,    \
+            var_Fw[Qarg]*s_w**2 + var_Fw[Qarg+1]*c_w**2
+        var_Fw[Qarg+2] =  c_w*s_w*(var_Fw[Qarg] - var_Fw[Qarg+1]) + (c_w**2-s_w**2)*var_Fw[Qarg+2]
+        covar_Fw[Qarg:] =  covar_Fw[Qarg]*c_w**2 + covar_Fw[Qarg+1]*s_w**2 ,    \
+            covar_Fw[Qarg]*s_w**2 + covar_Fw[Qarg+1]*c_w**2
+    return stokes_Fw,var_Fw,covar_Fw
+
+# ------------------------------------
+def chisqanalysis(obsname,nstokeserr_Jw,nerr_Jw,okchi_w):
+    # chisq analysis by quartiles in var, 
+    #   as-binned data (f1) then binned again with adjacent bins (f2) and alternating bins (f3)
+    # to judge errors above Poisson, and covariance
+
+    cycles,wavs = nstokeserr_Jw.shape
+    f0=open(obsname+"_chi2cycle_Jw.txt",'ab')
+    f1=open(obsname+"_chi2cycle_Jq.txt",'ab')
+    f2=open(obsname+"_chi2cycle2bin_Jq.txt",'ab')
+    f3=open(obsname+"_chi2cyclealtbin_Jq.txt",'ab')
+
+    np.savetxt(f0,np.vstack((np.arange(wavs),okchi_w,nstokeserr_Jw,nerr_Jw)).T,fmt="%5i %2i "+2*cycles*"%12.8f ")
+
+    Wsort_Jw = np.argsort(nerr_Jw[:,okchi_w],axis=1)
+    Wsort_JqW = Wsort_Jw[:,:(okchi_w.sum()-(okchi_w.sum() % 4))].reshape((cycles,4,-1))
+    chi2cycle_qJ = np.zeros((4,cycles))
+    for J in range(cycles):
+        for q in range(4):
+            loc,scale = norm.fit(nstokeserr_Jw[J,okchi_w][Wsort_JqW[J,q]]/nerr_Jw[J,okchi_w][Wsort_JqW[J,q]])
+            chi2cycle_qJ[q,J] = scale**2
+    np.savetxt(f1,np.vstack((range(cycles),chi2cycle_qJ)).T,fmt="%3i "+4*"%8.3f ")
+
+    ok2bin_w = (okchi_w[:-1] & okchi_w[1:])
+    w1binlist = np.where(ok2bin_w)[0][::2]
+    w2binlist = [w+1 for w in w1binlist]
+    nstokeserr2bin_Jw = np.zeros_like(nstokeserr_Jw)
+    nerr2bin_Jw = np.zeros_like(nerr_Jw)
+    nstokeserr2bin_Jw[:,w1binlist] = (nstokeserr_Jw[:,w1binlist]+nstokeserr_Jw[:,w2binlist])/2.
+    nerr2bin_Jw[:,w1binlist] = np.sqrt((nerr_Jw[:,w1binlist]**2 + nerr_Jw[:,w2binlist]**2))/2.
+    Wsort_Jw = np.argsort(nerr2bin_Jw[:,w1binlist],axis=1)
+    Wsort_JqW = Wsort_Jw[:,:(len(w1binlist)-(len(w1binlist) % 4))].reshape((cycles,4,-1))
+    chi2cycle_qJ = np.zeros((4,cycles))
+    for J in range(cycles):
+        for q in range(4):
+            loc,scale = norm.fit(nstokeserr2bin_Jw[J,w1binlist][Wsort_JqW[J,q]]/    \
+                nerr2bin_Jw[J,w1binlist][Wsort_JqW[J,q]])
+            chi2cycle_qJ[q,J] = scale**2
+    np.savetxt(f2,np.vstack((range(cycles),chi2cycle_qJ)).T,fmt="%3i "+4*"%8.3f ")
+
+    wevenlist = list(np.where(okchi_w)[0][::2]) 
+    if (len(wevenlist) % 2): wevenlist.pop()     
+    woddlist = list(np.where(okchi_w)[0][1::2])
+    if (len(woddlist) % 2): woddlist.pop() 
+    w1binlist = wevenlist[::2]+woddlist[::2]
+    w2binlist = wevenlist[1::2]+woddlist[1::2] 
+    nstokeserraltbin_Jw = np.zeros_like(nstokeserr_Jw)
+    nerraltbin_Jw = np.zeros_like(nerr_Jw)
+    nstokeserraltbin_Jw[:,w1binlist] = (nstokeserr_Jw[:,w1binlist]+nstokeserr_Jw[:,w2binlist])/2.
+    nerraltbin_Jw[:,w1binlist] = np.sqrt((nerr_Jw[:,w1binlist]**2 + nerr_Jw[:,w2binlist]**2))/2.
+    Wsort_Jw = np.argsort(nerraltbin_Jw[:,w1binlist],axis=1)
+    Wsort_JqW = Wsort_Jw[:,:(len(w1binlist)-(len(w1binlist) % 4))].reshape((cycles,4,-1))
+    chi2cycle_qJ = np.zeros((4,cycles))
+    for J in range(cycles):
+        for q in range(4):
+            loc,scale = norm.fit(nstokeserraltbin_Jw[J,w1binlist][Wsort_JqW[J,q]]/  \
+                nerraltbin_Jw[J,w1binlist][Wsort_JqW[J,q]])
+            chi2cycle_qJ[q,J] = scale**2
+    np.savetxt(f3,np.vstack((range(cycles),chi2cycle_qJ)).T,fmt="%3i "+4*"%8.3f ")
+
+    f1.close()
+    f2.close()
+    f3.close()
+
+    return
 
 if __name__=='__main__':
     infilelist=[x for x in sys.argv[1:] if x.count('.fits')]


### PR DESCRIPTION
scripts/correct_files.py        fixed cross-reference to polsalt
                                updated definition of tilt
scripts/specpolextract_sc.py    fix extraction, update of BPM for 300-line grating
			        fix propagation of variance in extraction
				add resampling covariance extension
				large update to support target/comparison extraction
scripts/specpolfinalstokes.py   fix case where no chisq is known
				fix multi-cycle BPM handling
				multi-cycles now average on normalized stokes basis
				improve syserr, chisq reporting
scripts/specpolview.py          use covariance extension
				added "connect" (=hist) and "type" (=Iqu) options
				moved "errors" to be a proper separate option
scripts/reducepoldata_sc.py     update to support target/comparison extraction
scripts/specpolflux.py          allowed GR-ANGLE for flux std to be within 0.1
				update covariance extension
				moved new configmap to:
polsalt/specpolutils.py
polsalt/specpolwavmap.py        revert to ystart arcdb line if rms in L0 cofs too large
polsalt/specpolrawstokes.py     use covariance extension