### PR TITLE
1211 kndec19_1

### DIFF
--- a/polsalt/data/RSS_Gain_Correction_20061030_v00.txt
+++ b/polsalt/data/RSS_Gain_Correction_20061030_v00.txt
@@ -1,0 +1,8 @@
+# RSS CCD amplifier gain
+# Correction to SALT pipeline fits header values
+# dummy for debug
+# Gain Speed/amp  0     1      2      3      4      5
+  FAINT  SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  FAINT  FAST 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  BRIGHT SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000    
+  BRIGHT FAST 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000   

--- a/polsalt/data/RSS_Gain_Correction_20180705_v01.txt
+++ b/polsalt/data/RSS_Gain_Correction_20180705_v01.txt
@@ -1,0 +1,10 @@
+# RSS CCD amplifier gain
+# Correction to SALT pipeline fits header values
+# Bright/Fast 20180705
+# Gain Speed/amp  0     1      2      3      4      5
+  FAINT  SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  FAINT  FAST 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  BRIGHT SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000    
+  BRIGHT FAST 1.0000 1.0891 0.8852 1.2422 1.1576 1.2497
+
+   

--- a/polsalt/data/RSS_Gain_Correction_20180726_v01.txt
+++ b/polsalt/data/RSS_Gain_Correction_20180726_v01.txt
@@ -1,0 +1,9 @@
+# RSS CCD amplifier gain
+# Correction to SALT pipeline fits header values
+# Bright/Fast 20180726
+# Gain Speed/amp  0     1      2      3      4      5
+  FAINT  SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  FAINT  FAST 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  BRIGHT SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000    
+  BRIGHT FAST 1.0000 1.2680 1.1390 1.2198 1.2179 1.0967
+   

--- a/polsalt/data/RSS_Gain_Correction_20181024_v01.txt
+++ b/polsalt/data/RSS_Gain_Correction_20181024_v01.txt
@@ -1,0 +1,9 @@
+# RSS CCD amplifier gain
+# Correction to SALT pipeline fits header values
+# Bright/Fast 20181026
+# Gain Speed/amp  0     1      2      3      4      5
+  FAINT  SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  FAINT  FAST 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000
+  BRIGHT SLOW 1.0000 1.0000 1.0000 1.0000 1.0000 1.0000    
+  BRIGHT FAST 1.0000 0.9983 1.1585 0.7434 1.1483 0.8597
+   

--- a/scripts/specpolextract_sc.py
+++ b/scripts/specpolextract_sc.py
@@ -2,6 +2,7 @@
 """
 
 extract spectropolarimetry from image or images
+split into correct and spectrum-extract
 
 """
 
@@ -21,168 +22,248 @@ polsaltdir = '/'.join(os.path.realpath(__file__).split('/')[:-2])
 datadir = polsaltdir+'/polsalt/data/'
 sys.path.extend((polsaltdir+'/polsalt/',))
 
-def specpolextract_sc(infilelist,*posargs,**kwargs):  
-    print '\nspecpolextract_sc version: 20171226'
-    if len(posargs):
-        print "Incorrect call of specpolextract_sc.  Likely need to update reducepoldata_sc.py from:"
-        print polsaltdir+'/scripts/reducepoldata_sc.py'
-        exit()
+from rssmaptools import ccdcenter
+from specpolutils import datedfile, configmap
+
+def specpolcorrect_sc(infileList,**kwargs):
+    print '\nspecpolcorrect_sc version: 20191123'
     logfile = kwargs.pop('logfile','salt.log')
     locatewindow = kwargs.pop('locate',(-120.,120.))
     xtrwindow = kwargs.pop('extract',10.)
-    docomp = kwargs.pop('docomp',False)
     useoldc = kwargs.pop('useoldc',False)
 
     log = open(logfile,'a')
-    print >> log, '\nspecpolextract_sc version: 20171226'  
+    print >> log, '\nspecpolcorrect_sc version: 20191210'  
 
-  # first estimate image tilt on brightest spectrum
-    tilt_i = np.full(len(infilelist),np.nan)
-    filestocorrect = 0
+  # group the files together
+    confitemlist = ['GRATING','GR-ANGLE','CAMANG','BVISITID']
+    obs_i,config_i,obstab,configtab = configmap(infileList, confitemlist)    
+    obss = len(obstab)
+    configs = len(configtab)
+    infiles = len(infileList)
+    wollaston_file=datadir+"wollaston.txt"
+    lam_m = np.loadtxt(wollaston_file,dtype=float,usecols=(0,))
+    rpix_om = np.loadtxt(wollaston_file,dtype=float,unpack=True,usecols=(1,2))     
+
+    for o in range(obss):
+        grating, grangle, camang, bvisitid = configtab[obstab[o]['config']]
+        objectname = obstab[o]['object']
+        fileListj = [infileList[i] for i in range(infiles) if obs_i[i]==o]
+      # first estimate image tilt on brightest spectrum
+        tilt_i = np.full(len(fileListj),np.nan)
+        filestocorrect = 0
+        infilelist = sorted(fileListj)
+        for i,img in enumerate(infilelist):
+            if (useoldc & os.path.exists('c' + img)): continue
+            hdul = pyfits.open(img)
+            if hdul[0].header['CCDTYPE'] == 'ARC': continue
+            filestocorrect += 1
+            sci_orc = hdul['SCI'].data
+            rows, cols = sci_orc[0].shape
+            cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
+
+          # col_dC = columns C in each sample d=(0,1) centered at c_d (0,1)
+            if hdul[0].header['GRATING'].strip() == 'PG0300': 
+                c_d = (cols*np.array([.25,.5])).astype(int)                        # avoid 2nd order
+            else: c_d = (cols*np.array([.25,.75])).astype(int)
+            dc = c_d[1]-c_d[0]
+            col_dC = (np.arange(c_d[0]-.05*cols,c_d[0]+.05*cols) + dc*np.arange(2)[:,None]).astype(int)
+
+          # row_odR = rows R to sample centered on untilted polarimetric spectra (brightest in O)
+          #   as small as possible to avoid picking up more than one spectrum
+            row_o = np.zeros(2,dtype=int)
+            row_o[0] = np.argmax(np.median(sci_orc[0,:,(2*cols/5):(3*cols/5)],axis=1)).astype(int)
+            lam_c = hdul['WAV'].data[0,row_o[0]]
+            rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
+            raxis_o = (np.array([rows,0]) +   \
+                np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
+            row_o[1] = raxis_o[1] + row_o[0] - raxis_o[0]
+            drow = int(round(4*xtrwindow+0.01*dc*cbin)/rbin)   #  1% allowed tilt 
+
+            row_odR = (row_o[:,None,None] +  \
+                (rpix_oc[:,c_d]-rpix_oc[:,cols/2][:,None])[:,:,None]/rbin + np.arange(-drow,drow)).astype(int)
+
+            row_od = np.zeros((2,2))
+            for o,d in np.ndindex(2,2):
+                sci_Rc = sci_orc[o][row_odR[o,d]] 
+                row_od[o,d] = np.median(sci_Rc[:,col_dC[d]].sum(axis=1).argsort()[-17:])
+
+            yoff_o = rbin*(row_o - raxis_o)/8. 
+            tilt_i[i] = (row_od.mean(axis=0)[0]-row_od.mean(axis=0)[1])*float(cols)/float(dc)
+            print img,(": brtest O object at %6.1f arcsec, row: %4i, tilt: %4.0f" % (yoff_o[0],row_o[0],tilt_i[i]))
+            print >>log,img,(": brtest O object at %6.1f arcsec, row: %4i, tilt: %4.0f" % (yoff_o[0],row_o[0],tilt_i[i]))
+
+        if filestocorrect:
+            if ((yoff_o.min() < locatewindow[0]) | (yoff_o.max() > locatewindow[1])):
+                print "\nNOTE: science locate window may not contain brightest object\n"
+                print >>log,"\nNOTE: science locate window may not contain brightest object\n"
+            tilt = np.median(tilt_i[~np.isnan(tilt_i)])
+            print ("Median image tilt (cw,total,bins): %6.1f" % tilt)
+            print >>log,("Median image tilt (cw,total,bins): %6.1f" % tilt)
+            log.flush
+        
+          # straighten out the spectra
+            for img in infilelist:
+                if (useoldc & os.path.exists('c' + img)): continue
+                hdu=correct_files(pyfits.open(img),tilt=tilt)
+                hdu.writeto('c' + img, overwrite=True)
+                print 'c' + img
+                print >>log,'c' + img
+
+    return
+
+def specpolspectrum_sc(infileList,**kwargs):
+    print '\nspecpolspectrum_sc version: 20191123'
+    logfile = kwargs.pop('logfile','salt.log')
+    locatewindow = kwargs.pop('locate',(-120.,120.))    # arcsec relative to optical axis
+    xtrwindow = kwargs.pop('extract',10.)               # arcsec relative to located spectrum               
+                                                        # optional list t1,t2,lb1,lb2,rb1,rb2; default t2-t1
+    docomp = kwargs.pop('docomp',False)                 # comp locate window is inverse of locate window
+
+    log = open(logfile,'a')
+    print >> log, '\nspecpolspectrum_sc version: 20191123' 
+
+  # group the files together
+    confitemlist = ['GRATING','GR-ANGLE','CAMANG','BVISITID']
+    obs_i,config_i,obstab,configtab = configmap(infileList, confitemlist)    
+    obss = len(obstab)
+    configs = len(configtab)
+    infiles = len(infileList)
     wollaston_file=datadir+"wollaston.txt"
     lam_m = np.loadtxt(wollaston_file,dtype=float,usecols=(0,))
     rpix_om = np.loadtxt(wollaston_file,dtype=float,unpack=True,usecols=(1,2))
 
-    infilelist = sorted(infilelist)
-    for i,img in enumerate(infilelist):
-        if (useoldc & os.path.exists('c' + img)): continue
-        hdul = pyfits.open(img)
-        if hdul[0].header['CCDTYPE'] == 'ARC': continue
-        filestocorrect += 1
-        sci_orc = hdul['SCI'].data
+    for o in range(obss):
+        grating, grangle, camang, bvisitid = configtab[obstab[o]['config']]
+        objectname = obstab[o]['object']
+        fileListj = [infileList[i] for i in range(infiles) if obs_i[i]==o]
+      # get gain correction data
+        hdul0 = pyfits.open(fileListj[0])
+        sci_orc = hdul0['SCI'].data
         rows, cols = sci_orc[0].shape
-        cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
+        cbin, rbin = [int(x) for x in hdul0[0].header['CCDSUM'].split(" ")]
+        dateobs =  hdul0[0].header['DATE-OBS'].replace('-','')
+        utchour = int(hdul0[0].header['UTC-OBS'].split(':')[0])
+        mjdateobs = str(int(dateobs) - int(utchour < 10))
+        gain = hdul0[0].header['GAINSET']
+        speed = hdul0[0].header['ROSPEED']
+        rccenter_d, cgap_c = ccdcenter(hdul0['SCI'].data[0])
+        c_a = np.array([0, cgap_c[0]-1024/cbin+1, cgap_c[[0,1]].mean(),   \
+            cgap_c[1]+1024/cbin, cgap_c[[2,3]].mean(), cgap_c[3]+1024/cbin, cols])  
 
-      # col_dC = columns C in each sample d=(0,1) centered at c_d (0,1)
-        if hdul[0].header['GRATING'].strip() == 'PG0300': 
-            c_d = (cols*np.array([.25,.5])).astype(int)                        # avoid 2nd order
-        else: c_d = (cols*np.array([.25,.75])).astype(int)
-        dc = c_d[1]-c_d[0]
-        col_dC = (np.arange(c_d[0]-.05*cols,c_d[0]+.05*cols) + dc*np.arange(2)[:,None]).astype(int)
+        GainCorrectionFile = datedfile(datadir+"RSS_Gain_Correction_yyyymmdd_vnn.txt",mjdateobs)
+        mode_ld = np.loadtxt(GainCorrectionFile, dtype='string', usecols=(0,1))
+        lmode = np.where((mode_ld[:,0]==gain) & (mode_ld[:,1] == speed))[0][0]
+        gaincor_a = np.loadtxt(GainCorrectionFile, usecols=range(2,8), unpack=True).T[lmode]
+        gaincor_c = np.ones(cols)
+        for a in range(6):
+            if (gaincor_a[a] == 1.): continue
+            isa_c = ((np.arange(cols) >= c_a[a]) & (np.arange(cols) < c_a[a+1]))
+            gaincor_c[isa_c] = gaincor_a[a]
 
-      # row_odR = rows R to sample centered on untilted polarimetric spectra (brightest in O)
-      #   as small as possible to avoid picking up more than one spectrum
-        row_o = np.zeros(2,dtype=int)
-        row_o[0] = np.argmax(np.median(sci_orc[0,:,(2*cols/5):(3*cols/5)],axis=1)).astype(int)
-        lam_c = hdul['WAV'].data[0,row_o[0]]
-        rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
-        rcenter_o = (np.array([rows,0]) +   \
-            np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
-        row_o[1] = rcenter_o[1] + row_o[0] - rcenter_o[0]
-        drow = int(round(4*xtrwindow+0.01*dc*cbin)/rbin)   #  1% allowed tilt 
-
-        row_odR = (row_o[:,None,None] +  \
-            (rpix_oc[:,c_d]-rpix_oc[:,cols/2][:,None])[:,:,None]/rbin + np.arange(-drow,drow)).astype(int)
-
-        row_od = np.zeros((2,2))
-        for o,d in np.ndindex(2,2):
-            sci_Rc = sci_orc[o][row_odR[o,d]] 
-            row_od[o,d] = np.median(sci_Rc[:,col_dC[d]].sum(axis=1).argsort()[-17:])
-
-        yoff_o = rbin*(row_o - rcenter_o)/8. 
-        tilt_i[i] = (row_od.mean(axis=0)[0]-row_od.mean(axis=0)[1])*float(cols)/float(dc)
-        print img,(": brtest object at %6.1f arcsec, tilt: %3i" % (yoff_o[0],tilt_i[i]))
-        print >>log,img,(": brtest object at %6.1f arcsec, tilt: %3i" % (yoff_o[0],tilt_i[i]))
-
-    if filestocorrect:
-        if ((yoff_o.min() < locatewindow[0]) | (yoff_o.max() > locatewindow[1])):
-            print "\nNOTE: science locate window may not contain brightest object\n"
-            print >>log,"\nNOTE: science locate window may not contain brightest object\n"
-        tilt = np.median(tilt_i[~np.isnan(tilt_i)])
-        print "Median image tilt (cw,total,bins): ",tilt
-        print >>log,"Median image tilt (cw,total,bins): ",tilt
-        log.flush
+      # define locate and extraction windows
+        if (type(xtrwindow) == list):
+            if len(xtrwindow) != 6:
+                print ("Extract aperture list must have 6 elements: " & xtrwindow)
+                exit()
+            xtr_sd = np.array(xtrwindow).reshape((3,2))
+            docomp = False                  # these are relative to main target in locate window
+        else:
+            xtr_sd = np.array([[-xtrwindow/2.,xtrwindow/2.],    \
+                [-3.5*xtrwindow,-2.5*xtrwindow],[2.5*xtrwindow,3.5*xtrwindow]])
         
-    # straighten out the spectra
-        for img in infilelist:
-            if (useoldc & os.path.exists('c' + img)): continue
-            hdu=correct_files(pyfits.open(img),tilt=tilt)
-            hdu.writeto('c' + img, overwrite=True)
-            print 'c' + img
-            print >>log,'c' + img
+        print ("Extraction aperture (arcsecs), target: %6.1f %6.1f,  bkg1: %6.1f %6.1f,  bkg2: %6.1f %6.1f" % \
+            tuple(xtr_sd.flatten()))
+        print >>log, ("Extraction aperture (arcsecs), target: %6.1f %6.1f,  bkg1: %6.1f %6.1f,  bkg2: %6.1f %6.1f" % \
+            tuple(xtr_sd.flatten()))
 
-    infilelist = [ 'c'+file for file in infilelist ]
+      # process images
+        for i,img in enumerate(fileListj):
+            hdul = pyfits.open(img)
+            if hdul[0].header['LAMPID'].strip() != 'NONE': continue
+            sci_orc = hdul['SCI'].data
+            rows, cols = sci_orc[0].shape
+            cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
 
-    print ("Extraction aperture: %6.1f arcsec" % xtrwindow)
-    print >>log, ("Extraction aperture: %6.1f arcsec" % xtrwindow)
-    for img in infilelist:
-        hdul = pyfits.open(img)
-        if hdul[0].header['LAMPID'].strip() != 'NONE': continue
-        sci_orc = hdul['SCI'].data
-        rows, cols = sci_orc[0].shape
-        cbin, rbin = [int(x) for x in hdul[0].header['CCDSUM'].split(" ")]
+          # find row of O and E spectrum, center ccd only
+            hduw = pyfits.open(img[1:])         # compute axis row using wavmap from wm (ok at col center)                                      
+            wave_orc = hduw['WAV'].data           
+            lam_c = wave_orc[0,rows/2]
+            rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
+            raxis_o = (np.array([rows,0]) +   \
+                np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
+            drowlocate_d = (np.round(8*np.array(locatewindow)/rbin)).astype(int)    # locate window relative to axis in rows
+            sci_or = np.median(sci_orc[:,:,(cols/3):(2*cols/3)],axis=2)             # vertical profile, center ccd
 
-      # find row center of O and E
-        hduw = pyfits.open(img[1:])                                         # use wavmap from wm (cwm messed up)                                      
-        wave_orc = hduw['WAV'].data           
-        lam_c = wave_orc[0,rows/2]
-        rpix_oc = interp1d(lam_m,rpix_om,kind='cubic',bounds_error=False)(lam_c)
-        rcenter_o = (np.array([rows,0]) +   \
-            np.array([-1.,1.])*0.5*(rpix_oc[1,cols/2] - rpix_oc[0,cols/2])/rbin).astype(int)
-        drow_d = (np.round(8*np.array(locatewindow)/rbin)).astype(int)
-        sci_or = sci_orc.mean(axis=2)
-        droff = 0.
-                                    
-        if docomp:                         # for comp, offset by row offset of brtest O outside locate window
-            userow_r =  np.in1d(np.arange(rows),(rcenter_o[0] + np.arange(*drow_d)),invert=True)
+          # fine locate window is twice the nominal extraction aper (20 arcsec), 
+          #   offset by row offset of brtest O in locate window (dcomp, outside locate window)                                   
+            invert=docomp                         
+            userow_r =  np.in1d(np.arange(rows),(raxis_o[0] + np.arange(*drowlocate_d)),invert=invert)
             rlist = np.where(userow_r)[0]
-            droff = rlist[np.argmax(sci_or[0,userow_r])] - rcenter_o[0]
+            droff = rlist[np.argmax(sci_or[0,userow_r])] - raxis_o[0]
+            drowfinelocate_d = droff + np.array([-1,1])*int(8*10./rbin)
+            
+            row_o = np.zeros(2,dtype=int)
+            for o in (0,1):
+                userow_r =  np.in1d(np.arange(rows),(raxis_o[o] + np.arange(*drowfinelocate_d)))
+                rlist = np.where(userow_r)[0]
+                row_o[o] = rlist[0] + np.median(sci_or[o][rlist].argsort()[-17:])
+            xtrrow_osd = (row_o[:,None,None] + 8.*xtr_sd[None,:,:]/rbin).astype(int)
 
-        row_o = np.zeros(2,dtype=int)
-        for o in (0,1):
-            userow_r =  np.in1d(np.arange(rows),(rcenter_o[o] + np.arange(*drow_d) + droff))
-            rlist = np.where(userow_r)[0]
-            row_o[o] = rlist[0] + np.median(sci_or[o][rlist].argsort()[-17:])
+          # establish the wavelength range to be used, based on first img, so extractions match
+            if (i==0):
+                wbin = wave_orc[0,row_o[0],cols/2]-wave_orc[0,row_o[0],(cols/2-1)]   # bin to nearest power of 2 angstroms          
+                wbin = 2.**(np.rint(np.log2(wbin)))                                 
+                wmin_oc = wave_orc.max(axis=1)                                     
+                wmin = max((wmin_oc[0][wmin_oc[0]>0]).min(), (wmin_oc[1][wmin_oc[1]>0]).min())  # ignore wavmap 0 values        
+                wmax = wave_orc[:,row_o].reshape((2,-1)).max(axis=1).min()           # use wavs that are in both beams          
+                wmin = (np.ceil(wmin/wbin)+1)*wbin                       
+                wmax = (np.floor(wmax/wbin)-1)*wbin                      
 
-      # establish the wavelength range to be used
-        wbin = wave_orc[0,row_o[0],cols/2]-wave_orc[0,row_o[0],(cols/2-1)]   # bin to nearest power of 2 angstroms          
-        wbin = 2.**(np.rint(np.log2(wbin)))                                 
-        wmin_oc = wave_orc.max(axis=1)                                     
-        wmin = max((wmin_oc[0][wmin_oc[0]>0]).min(), (wmin_oc[1][wmin_oc[1]>0]).min())  # ignore wavmap 0 values        
-        wmax = wave_orc[:,row_o].reshape((2,-1)).max(axis=1).min()           # use wavs that are in both beams          
-        wmin = (np.ceil(wmin/wbin)+1)*wbin                       
-        wmax = (np.floor(wmax/wbin)-1)*wbin 
-        drow = int(4*xtrwindow/rbin)
-        yoff_o = rbin*(row_o - rcenter_o)/8.                     
+            o = 0
+            xtrrow_sd = xtrrow_osd[o]
+            data = hdul['SCI'].data[o]/gaincor_c[None,:]
+            var = hdul['VAR'].data[o]/gaincor_c[None,:]**2
+            bpm = hdul['BPM'].data[o]
+            wave = wave_orc[o]
 
-        o = 0 
-        row1 = row_o[o] - drow
-        row2 = row_o[o] + drow 
-        data = hdul['SCI'].data[o]
-        var = hdul['VAR'].data[o]
-        bpm = hdul['BPM'].data[o]
-        wave = wave_orc[o]
+            w, fo, vo, co, bo = extract(data, var, bpm, wave, xtrrow_sd, wmin, wmax, wbin)
 
-        w, fo, vo, co, bo = extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin)
+            o = 1
+            xtrrow_sd = xtrrow_osd[o]
+            data = hdul['SCI'].data[o]/gaincor_c[None,:]
+            var = hdul['VAR'].data[o]/gaincor_c[None,:]**2
+            bpm = hdul['BPM'].data[o]
+            wave = wave_orc[o]
 
-        o = 1
-        row1 = row_o[o] - drow
-        row2 = row_o[o] + drow   
-        data = hdul['SCI'].data[o]
-        var = hdul['VAR'].data[o]
-        bpm = hdul['BPM'].data[o]
-        wave = wave_orc[o]
-
-        w, fe, ve, ce, be = extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin)
+            w, fe, ve, ce, be = extract(data, var, bpm, wave, xtrrow_sd, wmin, wmax, wbin)
     
-        sci_list = [[fo], [fe]]
-        var_list = [[vo], [ve]]
-        covar_list = [[co], [ce]]
-        bad_list = [[bo], [be]]
+            sci_list = [[fo], [fe]]
+            var_list = [[vo], [ve]]
+            covar_list = [[co], [ce]]
+            bad_list = [[bo], [be]]
 
-        outfile = 'e'+img
-        if docomp:
-            outfile = outfile.split('P')[0]+'P_comp_'+outfile.split('P')[1]
-            hdul[0].header['OBJECT'] = 'COMP_'+hdul[0].header['OBJECT']
-        write_spectra(w, sci_list, var_list, covar_list, bad_list,  hdul[0].header, wbin, outfile)
+            outfile = 'e'+img
+            datecor = GainCorrectionFile.split('_')[-2]
+            hdul[0].header.add_history('GainCorrection: '+datecor+6*' %6.4f' % tuple(gaincor_a))
+            if docomp:
+                outfile = outfile.split('P')[0]+'P_comp_'+outfile.split('P')[1]
+                hdul[0].header['OBJECT'] = 'COMP_'+hdul[0].header['OBJECT']
+            write_spectra(w, sci_list, var_list, covar_list, bad_list,  hdul[0].header, wbin, outfile)
 
-        print outfile,("  dyo,dye: %6.1f %6.1f arcsec" % tuple(yoff_o))
-        print >>log, (outfile," dyo,dye: %6.1f %6.1f arcsec" % tuple(yoff_o))
-        log.flush
+            print outfile,(("  ro "+3*"%4i %4i, "+"  re "+3*"%4i %4i, ") % tuple(xtrrow_osd.flatten()))
+            print >>log, outfile,("  ro "+3*"%4i %4i, "+"  re "+3*"%4i %4i, ") % tuple(xtrrow_osd.flatten())
+            log.flush
 
     return
 
-def extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin):
+def specpolextract_sc(infilelist,**kwargs):
+    specpolcorrect_sc(infilelist,**kwargs)
+    infilelist = [ 'c'+file for file in infilelist ]    
+    specpolspectrum_sc(infilelist,**kwargs)
+    return
+  
+def extract(data, var, bpm, wave, xtrrow_sd, wmin, wmax, wbin):
     """Extract the spectra
 
     Parameters
@@ -193,22 +274,33 @@ def extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin):
     var: _rc numpy.ndarray
         variance data for spectra
 
-    mask: _rc numpy.ndarray
-        mask data for spectra
+    bpm: _rc numpy.ndarray
+        bpm data for spectra
 
     wave: _rc numpy.ndarray
         wavelength map for spectra
+
+    xtrrow_sd: 3x2 int ndarray
+        extraction apertures (row1,row2) (inclusive) for target, bkg1, bkg2
 
    Returns
    -------
     
     """
+
+    rccenter_d, cgap_c = ccdcenter(data)
+    cbin = 2048/(cgap_c[2]-cgap_c[1]+1)                       # _A central amps in each ccd, to be marked bad
+    c_A = np.array([cgap_c[0]-1024/cbin, cgap_c[1]+1024/cbin -1, cgap_c[3]+1024/cbin -1])
+
     wave_W = np.arange(wmin, wmax, wbin)                    # _W = resampled wavelength bin edge
     Waves = wave_W.shape[0]
-    row0 = int((row1+row2)/2)
+    row0 = int((xtrrow_sd[0].sum())/2)
     wmask_c = ((wave[row0] > wmin) & (wave[row0] < (wmax+wbin)))   
     wave_C = wave[row0,wmask_c]                             # _C = original bin centers within wavelength limits
     cmin = np.where(wmask_c)[0][0]                          # column c of C=0
+    wave_A = 0.5*(wave[row0,c_A] + wave[row0,c_A+1])
+    W_A = ((wave_A - wmin)/wbin).astype(int)                # Wave index of central amps
+
     dwave_C = wave_C[1:]-wave_C[:-1]
     dwave_C = np.append(dwave_C,dwave_C[-1])
     dwavpoly = np.polyfit(wave_C-wave_C.mean(),dwave_C-dwave_C.mean(),3)
@@ -225,14 +317,15 @@ def extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin):
     binfrac_dW[binfrac_dW < 0.] = 0.
 
     #estimate the sky
+    Rows_s = np.diff(xtrrow_sd,axis=1)[:,0] + 1
     sky_W = np.zeros_like(wave_W)
     count = 0
-    drow = row2-row1
-    Rows = 2*drow
-    sky_RW = np.zeros((Rows,Waves))
+
+    sky_RW = np.zeros((Rows_s[1:].sum(),Waves))
     R = -1
-    for r in range(row1-3*drow, row1-2*drow) + range(row2+2*drow, row2+3*drow):
+    for r in range(xtrrow_sd[1,0],xtrrow_sd[1,1]+1) + range(xtrrow_sd[2,0],xtrrow_sd[2,1]+1):
         xmask_c = (wmask_c & (bpm[r]==0))
+        xmask_c[1:-1] &= (xmask_c[:-2] & xmask_c[2:])           # more conservative CR
         R += 1
         sky_RW[R] = np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c])
         sky_W += np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c])
@@ -245,16 +338,18 @@ def extract(data, var, bpm, wave, row1, row2, wmin, wmax, wbin):
     cov_W = np.zeros_like(wave_W)
     b_W = np.zeros_like(wave_W).astype(int)
 
-    for r in range(row1, row2):
+    for r in range(xtrrow_sd[0,0],xtrrow_sd[0,1]+1):
         xmask_c = (wmask_c & (bpm[r]==0))
+        xmask_c[1:-1] &= (xmask_c[:-2] & xmask_c[2:])           # more conservative CR
         f_W += np.interp(wave_W, wave[r, xmask_c], data[r, xmask_c]) - sky_W
         dv_W = (binfrac_dW**2*var[r,C_W+cmin][None,:]).sum(axis=0)        
         v_W += dv_W
         cov_W[:-1] += dv_W[:-1]*binfrac_dW[1,:-1]*binfrac_dW[2,1:]
         b_W += (np.interp(wave_W, wave[r, wmask_c], xmask_c[wmask_c].astype(float)) < 0.5).astype(int)
 
-    f_W /= binrat_W
-    b_W = ((b_W > 0.25*(row2-row1+1)) | (f_W == 0.) | (v_W == 0.)).astype('uint8')    # bad if 0 or > 25% spectrum bad
+    f_W /= binrat_W                                             # bad if 0 or > 25% spectrum bad:
+    b_W = ((b_W > 0.25*Rows_s[0]) | (f_W == 0.) | (v_W == 0.)).astype('uint8') 
+    b_W[W_A] = 2                                            # special badpix marker for central amps
 
     return wave_W, f_W, v_W, cov_W, b_W
 


### PR DESCRIPTION
polsalt/specpolutils.py         Provide angle_average to correctly handle 360 wrapping
polsalt/specpolrawstokes.py     Use angle_average of TELPA over hw pair for rawstokes _hw
                                Allow target and comp config to be different if wavcal different
				polsalt/data/RSS_Gain_Correction Added 20161030,20180705,20180726,20181008
				    files for correcting pipeline gains
scripts/specpolextract_sc.py    split into specpolcorrect_sc and specpolspectrum_sc for GUI
				multiple observations handled separately in correct and spectrum
--/specpolspectrum_sc           Use column median instead of mean in spectrum finder
				Fixed error in extraction window of docomp
			        Ensure extractions within an observation match, giving same config
			        Correct for gains using new file
			        Implement option to specify extraction apertures
			        Improved CR handling
			        Use two-step locate to eliminate interference of neighboring spectra
scripts/specpolflux.py          Add evaluation of amplifier gains when processing new db entry
                                Add dates to target names in flux cal history
			        Average HST flux standards down to 50 Ang bin to improve noise
scripts/specpolfinalstokes.py   Use angle_average of TELPA over raw_stokes for stokes